### PR TITLE
fix(readme): call `asPoint(m)` before `toLineProtocol()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ const queryPointsResult = client.queryPoints(
 for await (const row of queryPointsResult) {
     console.log(`avg is ${row.getField('avg', 'float')}`)
     console.log(`max is ${row.getField('max', 'float')}`)
-    console.log(`lp: ${row.toLineProtocol()}`)
+    console.log(`lp: ${row.asPoint('stat').toLineProtocol()}`)
 }
 ```
 


### PR DESCRIPTION
## Proposed Changes

- Convert the `PointValues` row to a point before converting to line protocol. `PointValues` doesn't have a `toLineProtocol()` method. https://github.com/InfluxCommunity/influxdb3-js/blob/c4bef5f4129d89e8c0a76612d0ed7ea0726433a3/packages/client/src/PointValues.ts#L499

## Checklist

- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
