### PR TITLE
chore(ci): use node21 to build instead node16 which is out of life

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,8 @@ workflows:
             branches:
               ignore: gh-pages
       - tests:
-          name: 'tests-node-16'
-          image: 'cimg/node:16.20'
+          name: 'tests-node-21'
+          image: 'cimg/node:21.4'
           filters:
             branches:
               ignore: gh-pages

--- a/packages/client/test/integration/e2e.test.ts
+++ b/packages/client/test/integration/e2e.test.ts
@@ -122,7 +122,7 @@ describe('e2e test', () => {
 
     await client.close()
     await rejects(client.query(query, database, queryType).next())
-  })
+  }).timeout(5_000)
 
   it('concurrent query', async () => {
     const {database, token, url} = getEnvVariables()


### PR DESCRIPTION
## Proposed Changes

Node 16 is now out of life, and some dependencies (tsup - https://github.com/InfluxCommunity/influxdb3-js/pull/182) no longer support this version. This PR drops the build with Node 16 and introduces a new CI build with Node 21.

<img width="639" alt="image" src="https://github.com/InfluxCommunity/influxdb3-js/assets/455137/14269d76-c126-4ff6-bd0f-bc292cc4331d">

https://github.com/nodejs/Release#release-schedule

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
