### PR TITLE
feat: adds QueryOptions and Custom headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - run:
           name: Run tests
           command: |
+            yarn flight:test
             yarn build
             yarn test:ci
             yarn apidoc:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
           name: Runs tests with coverage
           command: |
             yarn --version
+            yarn flight:test
             yarn run coverage:ci
       - run:
           name: Report test results to codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.8.0 [unreleased]
 
+### Breaking Changes
+
+1. [293](https://github.com/InfluxCommunity/influxdb3-js/pull/293): The Query API now uses a `QueryOptions` structure in `client.query()` methods.  The `queryType` and `queryParams` values are now wrapped inside of it.  QueryOptions also support adding custom headers.  Query parameters are changed from type `Map<string, QParamType>` to type `Record<string, QParamType>`.
+
 ## 0.7.0 [2024-03-01]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ import {InfluxDBClient, Point} from '@influxdata/influxdb3-client'
 ```
 
 Assign values for environment variables, and then instantiate `InfluxDBClient` inside of an asynchronous function.
-Please note that token is mandatory parameter.
+Please note that token is a mandatory parameter.
 Make sure to `close` the client when it's no longer needed for writing or querying.
 
 ```ts
@@ -109,7 +109,7 @@ async function main() {
 main()
 ```
 
-You can use provided constructor for `InfluxDBClient` instantiation using environment variables:
+You can also use a provided no argument constructor for `InfluxDBClient` instantiation using environment variables:
 
 ```ts
 
@@ -124,7 +124,7 @@ async function main() {
 main()
 ```
 
-You can also instantiate `InfluxDBClient` with connections string:
+You can also instantiate `InfluxDBClient` with a connection string:
 
 ```ts
 
@@ -150,7 +150,7 @@ await client.write(line, database)
 
 ### Query data
 
-To query data stored in InfluxDB, call `client.query` with an SQL query and the database (or bucket) name. To change to using InfluxQL change the queryType option to 'influxql'.
+To query data stored in InfluxDB, call `client.query` with an SQL query and the database (or bucket) name. To change to using InfluxQL add a QueryOptions object with the type 'influxql' (e.g. `client.query(query, database, { type: 'influxql'})`).
 
 ```ts
 // Execute query
@@ -170,14 +170,13 @@ for await (const row of queryResult) {
 }
 ```
 
-or use typesafe `PointValues` structure with `client.queryPoints`
+or use a typesafe `PointValues` structure with `client.queryPoints`
 
 ```ts
 const queryPointsResult = client.queryPoints(
     query,
     database,
-    queryType,
-    'stat'
+    queryOptions
 )
 
 for await (const row of queryPointsResult) {
@@ -209,6 +208,10 @@ To contribute to this project, fork the GitHub repository and send a pull reques
 For now, we're responsible for generating the Flight client. However, its Protobuf interfaces may undergo changes over time.
 
 To regenerate the Flight client, use the `yarn flight` command to execute the provided script. The script will clone the Flight Protobuf repository and generate new TypeScript files in `./src/generated/flight`.
+
+### Generate files for mock server
+
+To generate files needed for the mock server used in some tests, run the `yarn flight:test` command. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ To regenerate the Flight client, use the `yarn flight` command to execute the pr
 
 ### Generate files for mock server
 
-To generate files needed for the mock server used in some tests, run the `yarn flight:test` command. 
+To generate files needed for the mock server used in some tests, run the `yarn flight:test` command.
 
 ## License
 

--- a/examples/browser/src/exampleQueries.ts
+++ b/examples/browser/src/exampleQueries.ts
@@ -4,13 +4,15 @@ type ExampleQuery = {
   desc: string
 }
 
+export const measurement = 'demoBrowser'
+
 export const EXAMPLE_QUERIES: ExampleQuery[] = [
   {
     name: 'Raw',
     query: `\
 SELECT 
   "Temperature", "Humidity", "time"
-FROM "stat"
+FROM "${measurement}"
 WHERE
   time >= now() - interval '1 hour'`,
     desc: `\
@@ -30,7 +32,7 @@ calculate:
     query: `\
 SELECT 
   MIN("CO2") as minCO2, AVG("CO2") as avgCO2, MAX("CO2") as maxCO2
-FROM "stat"
+FROM "${measurement}"
 WHERE
   time >= now() - interval '1 hour';`,
   },
@@ -44,7 +46,7 @@ and sort by it`,
     query: `\
 SELECT 
   "Device", AVG("Temperature") as avgTemperature
-FROM "stat"
+FROM "${measurement}"
 WHERE
   time >= now() - interval '1 hour'
 GROUP BY "Device"
@@ -61,7 +63,7 @@ for each window calculate
 SELECT
   date_bin('5 minutes', "time") as window_start,
   AVG("Humidity") as avgHumidity
-FROM "stat"
+FROM "${measurement}"
 WHERE
   "time" >= now() - interval '1 hour'
 GROUP BY window_start
@@ -78,7 +80,7 @@ from past 1 hour`,
 SELECT 
   "Device",
   CORR("Humidity", "Temperature") AS correlation
-FROM "stat"
+FROM "${measurement}"
 WHERE
   time >= now() - interval '1 hour'
 GROUP BY "Device";`,

--- a/examples/browser/src/main.ts
+++ b/examples/browser/src/main.ts
@@ -1,7 +1,7 @@
 import {InfluxDBClient, Point} from '@influxdata/influxdb3-client-browser'
 
 import * as view from './view'
-import {EXAMPLE_QUERIES} from './exampleQueries'
+import {EXAMPLE_QUERIES, measurement} from './exampleQueries'
 
 /*********** initial values ***********/
 
@@ -45,7 +45,6 @@ const token = import.meta.env.VITE_INFLUXDB_TOKEN
 const host = '/influx' // vite proxy
 
 // This query type can either be 'sql' or 'influxql'
-const queryType = 'sql'
 
 const client = new InfluxDBClient({host, token})
 
@@ -57,7 +56,7 @@ view.setOnRandomize(() => {
 
 view.setOnWrite(async () => {
   const data = view.getWriteInput()
-  const p = Point.measurement('stat')
+  const p = Point.measurement(measurement)
     .setTag('Device', data['Device'])
     .setFloatField('Temperature', data['Temperature'])
     .setFloatField('Humidity', data['Humidity'])
@@ -82,7 +81,8 @@ view.setOnWrite(async () => {
 
 view.setOnQuery(async () => {
   const query = view.getQuery()
-  const queryResult = client.query(query, database, queryType)
+  // Query type can either be 'sql' or 'influxql'
+  const queryResult = client.query(query, database, { type: 'sql', })
 
   try {
     const firstRow = (await queryResult.next()).value

--- a/examples/browser/src/main.ts
+++ b/examples/browser/src/main.ts
@@ -82,7 +82,7 @@ view.setOnWrite(async () => {
 view.setOnQuery(async () => {
   const query = view.getQuery()
   // Query type can either be 'sql' or 'influxql'
-  const queryResult = client.query(query, database, { type: 'sql', })
+  const queryResult = client.query(query, database, {type: 'sql'})
 
   try {
     const firstRow = (await queryResult.next()).value

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:unit": "yarn workspaces run test:unit",
     "coverage": "cd packages/client && yarn build && yarn coverage",
     "coverage:ci": "cd packages/client && yarn build && yarn coverage:ci",
-    "flight": "node ./scripts/generate-flight"
+    "flight": "node ./scripts/generate-flight",
+    "flight:test": "node ./scripts/generate-flight test"
   },
   "homepage": "https://github.com/InfluxCommunity/influxdb3-js",
   "repository": {

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -177,7 +177,8 @@ export default class InfluxDBClient {
   query(
     query: string,
     database?: string,
-    queryOptions: QueryOptions = DEFAULT_QueryOptions
+    queryOptions: Partial<QueryOptions> = this._options.queryOptions ??
+      DEFAULT_QueryOptions
   ): AsyncGenerator<Record<string, any>, void, void> {
     const options = this._mergeQueryOptions(queryOptions)
     return this._queryApi.query(
@@ -195,12 +196,22 @@ export default class InfluxDBClient {
    * @param query - The query string.
    * @param database - The name of the database to query.
    * @param queryOptions - The type of query (default: \{type: 'sql'\}).
+   * @example
+   *
+   * ```typescript
+   * client.queryPoints(query, database, {
+   *       type: 'sql',
+   *       params: {location: 'N_Ray_11'},
+   *     })
+   * ```
+   *
    * @returns An async generator that yields PointValues object.
    */
   queryPoints(
     query: string,
     database?: string,
-    queryOptions: QueryOptions = DEFAULT_QueryOptions,
+    queryOptions: Partial<QueryOptions> = this._options.queryOptions ??
+      DEFAULT_QueryOptions
   ): AsyncGenerator<PointValues, void, void> {
     const options = this._mergeQueryOptions(queryOptions)
     return this._queryApi.queryPoints(

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -164,11 +164,11 @@ export default class InfluxDBClient {
    * @param queryOptions - The options for the query (default: \{ type: 'sql' \}).
    * @example
    * ```typescript
-   *    client.query('SELECT * from testData', 'CI_TEST', {
+   *    client.query('SELECT * from net', 'traffic_db', {
    *       type: 'sql',
    *       headers: {
-   *         'channel-pref': 'eu-123',
-   *         'notify': 'balthazar',
+   *         'channel-pref': 'eu-west-7',
+   *         'notify': 'central',
    *       },
    *     })
    * ```
@@ -199,9 +199,9 @@ export default class InfluxDBClient {
    * @example
    *
    * ```typescript
-   * client.queryPoints(query, database, {
+   * client.queryPoints('SELECT * FROM cpu', 'performance_db', {
    *       type: 'sql',
-   *       params: {location: 'N_Ray_11'},
+   *       params: {register: 'rax'},
    *     })
    * ```
    *

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -161,7 +161,7 @@ export default class InfluxDBClient {
    *
    * @param query - The query string.
    * @param database - The name of the database to query.
-   * @param queryOptions - The options for the query (default: { type: 'sql' }).
+   * @param queryOptions - The options for the query (default: \{ type: 'sql' \}).
    * @example
    * ```typescript
    *    client.query('SELECT * from testData', 'CI_TEST', {
@@ -194,7 +194,7 @@ export default class InfluxDBClient {
    *
    * @param query - The query string.
    * @param database - The name of the database to query.
-   * @param queryOptions - The type of query (default: {type: 'sql'}).
+   * @param queryOptions - The type of query (default: \{type: 'sql'\}).
    * @returns An async generator that yields PointValues object.
    */
   queryPoints(

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -99,10 +99,16 @@ export default class InfluxDBClient {
   }
 
   private _mergeWriteOptions = (writeOptions?: Partial<WriteOptions>) => {
-    return {
+    const headerMerge: Record<string, string> = {
+      ...this._options.writeOptions?.headers,
+      ...writeOptions?.headers,
+    }
+    const result = {
       ...this._options.writeOptions,
       ...writeOptions,
     }
+    result.headers = headerMerge
+    return result
   }
 
   /**

--- a/packages/client/src/QueryApi.ts
+++ b/packages/client/src/QueryApi.ts
@@ -1,5 +1,5 @@
 import {PointValues} from './PointValues'
-import {QueryType} from './options'
+import {QueryOptions} from './options'
 
 export type QParamType = string | number | boolean
 
@@ -12,15 +12,13 @@ export default interface QueryApi {
    *
    * @param query - The query string.
    * @param database - The name of the database to query.
-   * @param queryType - The type of query (default: 'sql').
-   * @param queryParams - for sql queries parameters to be used
+   * @param options - options applied to the query (default: { type: 'sql'}).
    * @returns An async generator that yields maps of string keys to any values.
    */
   query(
     query: string,
     database: string,
-    queryType: QueryType,
-    queryParams?: Map<string, QParamType>
+    options: QueryOptions
   ): AsyncGenerator<Record<string, any>, void, void>
 
   /**
@@ -28,15 +26,13 @@ export default interface QueryApi {
    *
    * @param query - The query string.
    * @param database - The name of the database to query.
-   * @param queryType - The type of query (default: 'sql').
-   * @param queryParams - for sql queries parameters to be used
+   * @param options - Options for the query (default: {type: 'sql'}).
    * @returns An async generator that yields PointValues object.
    */
   queryPoints(
     query: string,
     database: string,
-    queryType: QueryType,
-    queryParams?: Map<string, QParamType>
+    options: QueryOptions
   ): AsyncGenerator<PointValues, void, void>
 
   close(): Promise<void>

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -115,8 +115,6 @@ export default class QueryApiImpl implements QueryApi {
       query,
       database,
       options
-      // queryType,
-      //queryParams
     )
 
     for await (const batch of batches) {
@@ -142,8 +140,6 @@ export default class QueryApiImpl implements QueryApi {
       query,
       database,
       options
-      // options.type,
-      // options.params
     )
 
     for await (const batch of batches) {

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -2,13 +2,13 @@ import {RecordBatchReader, Type as ArrowType} from 'apache-arrow'
 import QueryApi, {QParamType} from '../QueryApi'
 import {Ticket} from '../generated/flight/Flight'
 import {FlightServiceClient} from '../generated/flight/Flight.client'
-import {ConnectionOptions, QueryType} from '../options'
+import {ConnectionOptions, QueryOptions, QueryType} from '../options'
 import {createInt32Uint8Array} from '../util/common'
 import {RpcMetadata, RpcOptions} from '@protobuf-ts/runtime-rpc'
 import {impl} from './implSelector'
 import {PointFieldType, PointValues} from '../PointValues'
 import {allParamsMatched, queryHasParams} from '../util/sql'
-import { CLIENT_LIB_VERSION } from "./version";
+import {CLIENT_LIB_VERSION} from './version'
 
 export type TicketDataType = {
   database: string
@@ -34,20 +34,19 @@ export default class QueryApiImpl implements QueryApi {
   prepareTicket(
     database: string,
     query: string,
-    queryType: QueryType,
-    queryParams: Map<string, QParamType> | undefined
+    options: QueryOptions
   ): Ticket {
     const ticketData: TicketDataType = {
       database: database,
       sql_query: query,
-      query_type: queryType,
+      query_type: options.type,
     }
 
-    if (queryParams) {
+    if (options.params) {
       const param: {[name: string]: QParamType | undefined} = {}
-      for (const key of queryParams.keys()) {
-        if (queryParams.get(key)) {
-          param[key] = queryParams.get(key)
+      for (const key of Object.keys(options.params)) {
+        if (options.params[key]) {
+          param[key] = options.params[key]
         }
       }
       ticketData['params'] = param as {[name: string]: QParamType | undefined}
@@ -74,12 +73,10 @@ export default class QueryApiImpl implements QueryApi {
   private async *_queryRawBatches(
     query: string,
     database: string,
-    queryType: QueryType,
-    queryParams?: Map<string, QParamType>,
-    queryHeaders?: Record<string, string>
+    options: QueryOptions
   ) {
-    if (queryParams && queryHasParams(query)) {
-      allParamsMatched(query, queryParams)
+    if (options.params && queryHasParams(query)) {
+      allParamsMatched(query, options.params)
     }
 
     if (this._closed) {
@@ -87,12 +84,12 @@ export default class QueryApiImpl implements QueryApi {
     }
     const client = this._flightClient
 
-    const ticket = this.prepareTicket(database, query, queryType, queryParams)
+    const ticket = this.prepareTicket(database, query, options) // queryType, queryParams)
 
-    const meta = this.prepareMetadata(queryHeaders)
-    const options: RpcOptions = {meta}
+    const meta = this.prepareMetadata(options.headers)
+    const rpcOptions: RpcOptions = {meta}
 
-    const flightDataStream = client.doGet(ticket, options)
+    const flightDataStream = client.doGet(ticket, rpcOptions)
 
     const binaryStream = (async function* () {
       for await (const flightData of flightDataStream.responses) {
@@ -112,14 +109,14 @@ export default class QueryApiImpl implements QueryApi {
   async *query(
     query: string,
     database: string,
-    queryType: QueryType,
-    queryParams?: Map<string, QParamType>
+    options: QueryOptions
   ): AsyncGenerator<Record<string, any>, void, void> {
     const batches = this._queryRawBatches(
       query,
       database,
-      queryType,
-      queryParams
+      options
+      // queryType,
+      //queryParams
     )
 
     for await (const batch of batches) {
@@ -139,14 +136,14 @@ export default class QueryApiImpl implements QueryApi {
   async *queryPoints(
     query: string,
     database: string,
-    queryType: QueryType,
-    queryParams?: Map<string, QParamType>
+    options: QueryOptions
   ): AsyncGenerator<PointValues, void, void> {
     const batches = this._queryRawBatches(
       query,
       database,
-      queryType,
-      queryParams
+      options
+      // options.type,
+      // options.params
     )
 
     for await (const batch of batches) {

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -111,11 +111,7 @@ export default class QueryApiImpl implements QueryApi {
     database: string,
     options: QueryOptions
   ): AsyncGenerator<Record<string, any>, void, void> {
-    const batches = this._queryRawBatches(
-      query,
-      database,
-      options
-    )
+    const batches = this._queryRawBatches(query, database, options)
 
     for await (const batch of batches) {
       for (let rowIndex = 0; rowIndex < batch.numRows; rowIndex++) {
@@ -136,11 +132,7 @@ export default class QueryApiImpl implements QueryApi {
     database: string,
     options: QueryOptions
   ): AsyncGenerator<PointValues, void, void> {
-    const batches = this._queryRawBatches(
-      query,
-      database,
-      options
-    )
+    const batches = this._queryRawBatches(query, database, options)
 
     for await (const batch of batches) {
       for (let rowIndex = 0; rowIndex < batch.numRows; rowIndex++) {

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -1,4 +1,5 @@
 import {Transport} from './transport'
+import {QParamType} from './QueryApi'
 
 /**
  * Option for the communication with InfluxDB server.
@@ -121,10 +122,21 @@ export const DEFAULT_WriteOptions: WriteOptions = {
 
 export type QueryType = 'sql' | 'influxql'
 
+export interface QueryOptions {
+  type: QueryType
+  headers?: Record<string, string>
+  params?: Record<string, QParamType>
+}
+
+export const DEFAULT_QueryOptions: QueryOptions = {
+  type: 'sql',
+}
+
 /**
  * Options used by {@link InfluxDBClient} .
  */
 export interface ClientOptions extends ConnectionOptions {
+  queryOptions?: Partial<QueryOptions>
   /** supplies and overrides default writing options */
   writeOptions?: Partial<WriteOptions>
   /** specifies custom transport */

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -53,12 +53,26 @@ export const DEFAULT_ConnectionOptions: Partial<ConnectionOptions> = {
 
 /**
  * Options used by {@link InfluxDBClient.write} .
+ *
+ * @example WriteOptions in write call
+ * ```typescript
+ *       client
+ *         .write(point, DATABASE, 'myOrg', {
+ *           headers: {
+ *             'channel-lane': 'reserved',
+ *             'notify-central': '30m',
+ *           },
+ *           precision: 'ns',
+ *           gzipThreshold: 1000,
+ *         })
+ * ```
  */
 export interface WriteOptions {
   /** Precision to use in writes for timestamp. default ns */
   precision?: WritePrecision
   /** HTTP headers that will be sent with every write request */
-  headers?: {[key: string]: string}
+  //headers?: {[key: string]: string}
+  headers?: Record<string, string>
   /** When specified, write bodies larger than the threshold are gzipped  */
   gzipThreshold?: number
   /** default tags

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -122,12 +122,34 @@ export const DEFAULT_WriteOptions: WriteOptions = {
 
 export type QueryType = 'sql' | 'influxql'
 
+/**
+ * Options used by {@link InfluxDBClient.query} and by {@link InfluxDBClient.queryPoints}.
+ *
+ * @example QueryOptions in queryCall
+ * ```typescript
+ * const data = client.query(query, 'CICD', {
+ *       type: 'sql',
+ *       headers: {
+ *         'one-off': 'totl', // one-off query header
+ *         'change-on': 'bltr', // over-write universal value
+ *       },
+ *       params: {
+ *         point: 'flg',
+ *         action: 'reverse',
+ *       },
+ *     })
+ * ```
+ */
 export interface QueryOptions {
+  /** Type of query being sent, e.g. 'sql' or 'influxql'.*/
   type: QueryType
+  /** Custom headers to add to the request.*/
   headers?: Record<string, string>
+  /** Parameters to accompany a query using them.*/
   params?: Record<string, QParamType>
 }
 
+/** Default QueryOptions */
 export const DEFAULT_QueryOptions: QueryOptions = {
   type: 'sql',
 }
@@ -136,8 +158,9 @@ export const DEFAULT_QueryOptions: QueryOptions = {
  * Options used by {@link InfluxDBClient} .
  */
 export interface ClientOptions extends ConnectionOptions {
+  /** supplies query options to be use with each and every query.*/
   queryOptions?: Partial<QueryOptions>
-  /** supplies and overrides default writing options */
+  /** supplies and overrides default writing options.*/
   writeOptions?: Partial<WriteOptions>
   /** specifies custom transport */
   transport?: Transport

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -58,7 +58,7 @@ export const DEFAULT_ConnectionOptions: Partial<ConnectionOptions> = {
  * @example WriteOptions in write call
  * ```typescript
  *       client
- *         .write(point, DATABASE, 'myOrg', {
+ *         .write(point, DATABASE, 'cpu', {
  *           headers: {
  *             'channel-lane': 'reserved',
  *             'notify-central': '30m',
@@ -81,10 +81,10 @@ export interface WriteOptions {
    * @example Default tags using client config
    * ```typescript
    * const client = new InfluxDBClient({
-   *            host: 'my-host',
+   *            host: 'https://eu-west-1-1.aws.cloud2.influxdata.com',
    *            writeOptions: {
    *              defaultTags: {
-   *                device: 'device-a',
+   *                device: 'nrdc-th-52-fd889e03',
    *              },
    *            },
    * })
@@ -98,11 +98,11 @@ export interface WriteOptions {
    * @example Default tags using writeOptions argument
    * ```typescript
    * const client = new InfluxDBClient({
-   *            host: 'my-host',
+   *            host: 'https://eu-west-1-1.aws.cloud2.influxdata.com',
    * })
    *
    * const defaultTags = {
-   *            device: 'device-a',
+   *            device: 'rpi5_0_0599e8d7',
    * }
    *
    * const p = Point.measurement('measurement').setField('num', 3)
@@ -127,14 +127,14 @@ export type QueryType = 'sql' | 'influxql'
  *
  * @example QueryOptions in queryCall
  * ```typescript
- * const data = client.query(query, 'CICD', {
+ * const data = client.query('SELECT * FROM drive', 'ev_onboard_45ae770c', {
  *       type: 'sql',
  *       headers: {
  *         'one-off': 'totl', // one-off query header
- *         'change-on': 'bltr', // over-write universal value
+ *         'change-on': 'shift1', // over-write universal value
  *       },
  *       params: {
- *         point: 'flg',
+ *         point: 'a7',
  *         action: 'reverse',
  *       },
  *     })

--- a/packages/client/src/util/sql.ts
+++ b/packages/client/src/util/sql.ts
@@ -8,13 +8,13 @@ export function queryHasParams(query: string): boolean {
 
 export function allParamsMatched(
   query: string,
-  qParams: Map<string, QParamType>
+  qParams: Record<string, QParamType>
 ): boolean {
   const matches = query.match(rgxParam)
 
   if (matches) {
     for (const match of matches) {
-      if (!qParams.get(match.trim().replace('$', ''))) {
+      if (!qParams[match.trim().replace('$', '')]) {
         throwReturn(
           new Error(
             `No parameter matching ${match} provided in the query params map`

--- a/packages/client/src/util/sql.ts
+++ b/packages/client/src/util/sql.ts
@@ -1,7 +1,7 @@
 import {QParamType} from '../QueryApi'
 import {throwReturn} from './common'
 
-const rgxParam = /(?:^|\W)\$(\w+)(?!\w)/g
+const rgxParam = /\$(\w+)/g
 export function queryHasParams(query: string): boolean {
   return !!query.match(rgxParam)
 }

--- a/packages/client/test/TestServer.ts
+++ b/packages/client/test/TestServer.ts
@@ -16,8 +16,6 @@ setLogger({
   },
 })
 
-// todo - when run in parallel can get conflicts?
-// so may need to increment port number or isolate runs
 const DEFAULT_PORT = 44404
 export class MockService {
   static callMeta: Map<string, Map<string, string[]>> = new Map()

--- a/packages/client/test/TestServer.ts
+++ b/packages/client/test/TestServer.ts
@@ -18,7 +18,7 @@ setLogger({
 
 // todo - when run in parallel can get conflicts?
 // so may need to increment port number or isolate runs
-const DEFAULT_PORT: number = 44404
+const DEFAULT_PORT = 44404
 export class MockService {
   static callMeta: Map<string, Map<string, string[]>> = new Map()
   static callTickets: Map<string, flt.Ticket> = new Map()

--- a/packages/client/test/integration/e2e.test.ts
+++ b/packages/client/test/integration/e2e.test.ts
@@ -310,10 +310,7 @@ describe('e2e test', () => {
       quality: 'Excellent',
     },
   ]
-
-  it('queries with parameters', async () => {
-    const {database, token, url} = getEnvVariables()
-
+  async function writeFrameSamples(client: InfluxDBClient, database: string) {
     const time = Date.now()
 
     let lp = ''
@@ -330,6 +327,12 @@ describe('e2e test', () => {
       }
     }
 
+    await client.write(lp, database)
+  }
+
+  it('queries with parameters', async () => {
+    const {database, token, url} = getEnvVariables()
+
     const client = new InfluxDBClient({
       host: url,
       token,
@@ -338,7 +341,7 @@ describe('e2e test', () => {
       },
     })
 
-    await client.write(lp, database)
+    await writeFrameSamples(client, database)
 
     await sleep(3_000)
 
@@ -355,29 +358,16 @@ describe('e2e test', () => {
       params: {director: 'J_Ford'},
     })
 
+    let count = 0
     for await (const row of data) {
+      count++
       expect(row['director']).to.equal('J_Ford')
     }
+    expect(count).to.be.greaterThan(0)
   }).timeout(5_000)
 
   it('queries to points with parameters', async () => {
     const {database, token, url} = getEnvVariables()
-
-    const time = Date.now()
-
-    let lp = ''
-
-    for (let i = 0; i < samples.length; i++) {
-      lp +=
-        `${samples[i].measurement},work=${samples[i].work},` +
-        `director=${samples[i].director} reel=${samples[i].reel}i,` +
-        `lumens=${samples[i].lumens},integ=${samples[i].integrity},` +
-        `sound=${samples[i].sound},quality="${samples[i].quality}"` +
-        ` ${time - i * 60000}`
-      if (i < samples.length - 1) {
-        lp += '\n'
-      }
-    }
 
     const client = new InfluxDBClient({
       host: url,
@@ -387,7 +377,7 @@ describe('e2e test', () => {
       },
     })
 
-    await client.write(lp, database)
+    await writeFrameSamples(client, database)
 
     await sleep(3_000)
 
@@ -404,8 +394,44 @@ describe('e2e test', () => {
       params: {director: 'N_Ray'},
     })
 
+    let count = 0
     for await (const point of points) {
+      count++
       expect(point.getTag('director')).to.equal('N_Ray')
     }
+    expect(count).to.be.greaterThan(0)
+  }).timeout(7_000)
+
+  it('queryies to points using influxql', async () => {
+    const {database, token, url} = getEnvVariables()
+    const client = new InfluxDBClient({
+      host: url,
+      token,
+      writeOptions: {
+        precision: 'ms',
+      },
+      queryOptions: {
+        type: 'influxql',
+      },
+    })
+    await writeFrameSamples(client, database)
+
+    await sleep(3_000)
+
+    const query = `SELECT *
+FROM "frame"
+WHERE
+time > now() - 1h
+AND
+"director" = 'H_Hathaway'`
+
+    const points = client.queryPoints(query, database)
+
+    let count = 0
+    for await (const point of points) {
+      count++
+      expect(point.getTag('director')).to.equal('H_Hathaway')
+    }
+    expect(count).to.be.greaterThan(0)
   }).timeout(7_000)
 })

--- a/packages/client/test/integration/queryAPI.test.ts
+++ b/packages/client/test/integration/queryAPI.test.ts
@@ -215,4 +215,30 @@ describe('query api tests', () => {
     expect(auth).to.equal('Bearer TEST_TOKEN')
     expect(agent).to.equal(USER_AGENT)
   })
+  it('sends a query with influxql type', async () => {
+    const client: InfluxDBClient = new InfluxDBClient({
+      host: `http://localhost:${server.port}`,
+      token: 'TEST_TOKEN',
+      database: 'CI_TEST',
+      queryOptions: {
+        type: 'influxql',
+      },
+    })
+    const data = client.query('SELECT * FROM wumpus', 'CI_TEST')
+    try {
+      await data.next()
+    } catch (e: any) {
+      assert.fail(`failed to get next data value from test server: ${e}`)
+    }
+    expect(MockService.callCount.doGet).to.equal(1)
+    const ticket = MockService.getCallTicketDecoded(
+      MockService.genCallId('doGet', 1)
+    )
+    expect(ticket).to.deep.equal({
+      database: 'CI_TEST',
+      sql_query: 'SELECT * FROM wumpus',
+      query_type: 'influxql',
+      params: {},
+    })
+  })
 })

--- a/packages/client/test/integration/queryAPI.test.ts
+++ b/packages/client/test/integration/queryAPI.test.ts
@@ -1,21 +1,24 @@
-import InfluxDBClient from '../../src/InfluxDBClient'
+import {expect, assert} from 'chai'
+import {InfluxDBClient, QueryOptions, DEFAULT_QueryOptions} from '../../src'
 import {MockService, TestServer} from '../TestServer'
 ;(BigInt.prototype as any).toJSON = function () {
   return this.toString()
 }
 
-function sleep(ms: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms)
-  })
-}
+const grpcVersion: string =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('../../../../node_modules/@grpc/grpc-js/package.json').version
+
+const USER_AGENT = `grpc-node-js/${grpcVersion}`
 
 describe('query api tests', () => {
   let server: TestServer
   before('start server', async () => {
-    console.log('starting server')
     server = new TestServer()
     await server.start()
+  })
+  beforeEach('reset server', async () => {
+    MockService.resetAll()
   })
   after('stop server', async () => {
     await server.shutdown()
@@ -27,48 +30,189 @@ describe('query api tests', () => {
       database: 'CI_TEST',
     })
     const query = `SELECT * FROM wumpus`
-    const queryType = 'sql'
-    const data = client.query(query, 'CI_TEST', queryType)
-    try {
-      const row: IteratorResult<Record<string, any>, void> = await data.next()
-      console.log(`CLIENT DEBUG DEBUG row ${JSON.stringify(row)}`)
-    } catch (e: any) {
-      console.error(`CLIENT DEBUG Caught error ${e}`)
-      console.error(e.stack)
-    }
-    console.log(`DEBUG MockService ${JSON.stringify(MockService.callCount)}`)
-    // const queryResult = await data.next()
-    //console.log(`DEBUG queryResult ${queryResult}`)
-    const doGetMap = MockService.callMeta.get(MockService.genCallId('doGet', 1))
-    if (doGetMap != null) {
-      console.log(
-        `DEBUG MockService.getCallMeta {doGet1} ${Array.from(doGetMap.keys())}`
-      )
-      for (const key of doGetMap.keys()) {
-        console.log(
-          `  DEBUG ${key}: ${MockService.getCallMeta(MockService.genCallId('doGet', 1), key)}`
-        )
-      }
-    }
-    console.log(
-      `DEBUG MockService.getCallTicket { doGet1 } ${JSON.stringify(MockService.getCallTicketDecoded(MockService.genCallId('doGet', 1)))}`
-    )
-    await sleep(3000)
-  }).timeout(600_000)
-  it('basic query', async () => {
-    const client: InfluxDBClient = new InfluxDBClient({
-      host: `http://localhost:${server.port}`,
-      token: `TEST_TOKEN`,
-      database: 'CI_TEST',
-    })
-    const query = `SELECT * FROM wumpus`
     const data = client.query(query, 'CI_TEST')
     try {
-      const row: IteratorResult<Record<string, any>, void> = await data.next()
-      console.log(`DEBUG row ${JSON.stringify(row)}`)
+      await data.next()
     } catch (e: any) {
-      console.error(`Caught error ${e}`)
-      console.error(e.stack)
+      assert.fail(`failed to get next data value from test server: ${e}`)
     }
+    expect(MockService.callCount.doGet).to.equal(1)
+    const doGetMap = MockService.callMeta.get(MockService.genCallId('doGet', 1))
+    expect(doGetMap?.get('user-agent')?.toString()).to.equal(USER_AGENT)
+    expect(doGetMap?.get('authorization')?.toString()).to.equal(
+      'Bearer TEST_TOKEN'
+    )
+    const ticket = MockService.getCallTicketDecoded(
+      MockService.genCallId('doGet', 1)
+    )
+    expect(ticket).to.deep.equal({
+      database: 'CI_TEST',
+      sql_query: 'SELECT * FROM wumpus',
+      query_type: 'sql',
+      params: {},
+    })
+  })
+  it('sends a query with options', async () => {
+    const client: InfluxDBClient = new InfluxDBClient({
+      host: `http://localhost:${server.port}`,
+      token: 'TEST_TOKEN',
+      database: 'CI_TEST',
+      headers: {
+        extra: 'yes',
+      },
+    })
+    const qOpts: QueryOptions = {
+      ...DEFAULT_QueryOptions,
+      headers: {
+        formula: 'x16',
+        'channel-pref': 'h3',
+      },
+    }
+    const query = `SELECT * FROM wumpus`
+    const data = client.query(query, 'CI_TEST', qOpts)
+    try {
+      await data.next()
+    } catch (e: any) {
+      assert.fail(`failed to get next data value from test server: ${e}`)
+    }
+    expect(MockService.callCount.doGet).to.equal(1)
+    const doGetMap = MockService.callMeta.get(MockService.genCallId('doGet', 1))
+    expect(doGetMap?.get('user-agent')?.toString()).to.equal(USER_AGENT)
+    expect(doGetMap?.get('authorization')?.toString()).to.equal(
+      'Bearer TEST_TOKEN'
+    )
+    expect(doGetMap?.get('extra')?.toString()).to.equal('yes')
+    expect(doGetMap?.get('formula')?.toString()).to.equal('x16')
+    expect(doGetMap?.get('channel-pref')?.toString()).to.equal('h3')
+    const ticket = MockService.getCallTicketDecoded(
+      MockService.genCallId('doGet', 1)
+    )
+    expect(ticket).to.deep.equal({
+      database: 'CI_TEST',
+      sql_query: 'SELECT * FROM wumpus',
+      query_type: 'sql',
+      params: {},
+    })
+  })
+  it('uses all header options on query', async () => {
+    const client = new InfluxDBClient({
+      host: `http://localhost:${server.port}`,
+      token: 'TEST_TOKEN',
+      database: 'CI_TEST',
+      headers: {
+        extra: 'yes', // universal header - shared by write and query APIs
+      },
+      queryOptions: {
+        headers: {
+          special: 'super', // universal query header
+          'change-it': 'caspar', // universal to be overwitten by call
+        },
+      },
+    })
+    const data = client.query('SELECT * from wumpus', 'CI_TEST', {
+      type: 'sql',
+      headers: {
+        'one-off': 'top of the league', // one-off query header
+        'change-it': 'balthazar', // over-write universal value
+      },
+    })
+    try {
+      // N.B. remember, it's a generator and next must be called to yield response
+      await data.next()
+    } catch (e: any) {
+      assert.fail(`failed to get next data value from test server: ${e}`)
+    }
+    expect(MockService.callCount.doGet).to.equal(1)
+    const extra = MockService.getCallMeta(
+      MockService.genCallId('doGet', 1),
+      'extra'
+    )?.toString()
+    const special = MockService.getCallMeta(
+      MockService.genCallId('doGet', 1),
+      'special'
+    )?.toString()
+    const oneOff = MockService.getCallMeta(
+      MockService.genCallId('doGet', 1),
+      'one-off'
+    )?.toString()
+    const changeIt = MockService.getCallMeta(
+      MockService.genCallId('doGet', 1),
+      'change-it'
+    )?.toString()
+    expect(extra).to.equal('yes')
+    expect(special).to.equal('super')
+    expect(oneOff).to.equal('top of the league')
+    expect(changeIt).to.equal('balthazar')
+  })
+  it('sends a query with headers and params', async () => {
+    const client: InfluxDBClient = new InfluxDBClient({
+      host: `http://localhost:${server.port}`,
+      token: 'TEST_TOKEN',
+      database: 'CI_TEST',
+      headers: {
+        extra: 'yes',
+      },
+      queryOptions: {
+        headers: {
+          special: 'super',
+        },
+        params: {
+          ecrivain: 'E_ZOLA',
+          acteur: 'R_NAVARRE',
+        },
+      },
+    })
+    const query =
+      'SELECT * FROM wumpus WHERE "writer" = $ecrivain AND "painter" = $peintre AND "actor" = $acteur'
+    const data = client.query(query, 'CI_TEST', {
+      type: 'sql',
+      headers: {
+        'one-off': 'top of the league', // one-off query header
+        'change-it': 'balthazar', // over-write universal value
+      },
+      params: {
+        peintre: 'F_LEGER',
+        acteur: 'A_ARTAUD',
+      },
+    })
+    try {
+      await data.next()
+    } catch (e: any) {
+      assert.fail(`failed to get next data value from test server: ${e}`)
+    }
+    expect(MockService.callCount.doGet).to.equal(1)
+    const ticket = MockService.getCallTicketDecoded(
+      MockService.genCallId('doGet', 1)
+    )
+    expect(ticket).to.deep.equal({
+      database: 'CI_TEST',
+      sql_query: query,
+      params: {
+        ecrivain: 'E_ZOLA',
+        acteur: 'A_ARTAUD',
+        peintre: 'F_LEGER',
+      },
+      query_type: 'sql',
+    })
+    const extra = MockService.getCallMeta(
+      MockService.genCallId('doGet', 1),
+      'extra'
+    )?.toString()
+    const special = MockService.getCallMeta(
+      MockService.genCallId('doGet', 1),
+      'special'
+    )?.toString()
+    const auth = MockService.getCallMeta(
+      MockService.genCallId('doGet', 1),
+      'authorization'
+    )?.toString()
+    const agent = MockService.getCallMeta(
+      MockService.genCallId('doGet', 1),
+      'user-agent'
+    )?.toString()
+    expect(extra).to.equal('yes')
+    expect(special).to.equal('super')
+    expect(auth).to.equal('Bearer TEST_TOKEN')
+    expect(agent).to.equal(USER_AGENT)
   })
 })

--- a/packages/client/test/integration/queryAPI.test.ts
+++ b/packages/client/test/integration/queryAPI.test.ts
@@ -1,0 +1,74 @@
+import InfluxDBClient from '../../src/InfluxDBClient'
+import {MockService, TestServer} from '../TestServer'
+;(BigInt.prototype as any).toJSON = function () {
+  return this.toString()
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+describe('query api tests', () => {
+  let server: TestServer
+  before('start server', async () => {
+    console.log('starting server')
+    server = new TestServer()
+    await server.start()
+  })
+  after('stop server', async () => {
+    await server.shutdown()
+  })
+  it('sends a query', async () => {
+    const client: InfluxDBClient = new InfluxDBClient({
+      host: `http://localhost:${server.port}`,
+      token: 'TEST_TOKEN',
+      database: 'CI_TEST',
+    })
+    const query = `SELECT * FROM wumpus`
+    const queryType = 'sql'
+    const data = client.query(query, 'CI_TEST', queryType)
+    try {
+      const row: IteratorResult<Record<string, any>, void> = await data.next()
+      console.log(`CLIENT DEBUG DEBUG row ${JSON.stringify(row)}`)
+    } catch (e: any) {
+      console.error(`CLIENT DEBUG Caught error ${e}`)
+      console.error(e.stack)
+    }
+    console.log(`DEBUG MockService ${JSON.stringify(MockService.callCount)}`)
+    // const queryResult = await data.next()
+    //console.log(`DEBUG queryResult ${queryResult}`)
+    const doGetMap = MockService.callMeta.get(MockService.genCallId('doGet', 1))
+    if (doGetMap != null) {
+      console.log(
+        `DEBUG MockService.getCallMeta {doGet1} ${Array.from(doGetMap.keys())}`
+      )
+      for (const key of doGetMap.keys()) {
+        console.log(
+          `  DEBUG ${key}: ${MockService.getCallMeta(MockService.genCallId('doGet', 1), key)}`
+        )
+      }
+    }
+    console.log(
+      `DEBUG MockService.getCallTicket { doGet1 } ${JSON.stringify(MockService.getCallTicketDecoded(MockService.genCallId('doGet', 1)))}`
+    )
+    await sleep(3000)
+  }).timeout(600_000)
+  it('basic query', async () => {
+    const client: InfluxDBClient = new InfluxDBClient({
+      host: `http://localhost:${server.port}`,
+      token: `TEST_TOKEN`,
+      database: 'CI_TEST',
+    })
+    const query = `SELECT * FROM wumpus`
+    const data = client.query(query, 'CI_TEST')
+    try {
+      const row: IteratorResult<Record<string, any>, void> = await data.next()
+      console.log(`DEBUG row ${JSON.stringify(row)}`)
+    } catch (e: any) {
+      console.error(`Caught error ${e}`)
+      console.error(e.stack)
+    }
+  })
+})

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -11,6 +11,7 @@ import {
 import type WriteApi from '../../src/WriteApi'
 import type QueryApi from '../../src/QueryApi'
 import {rejects} from 'assert'
+import nock from 'nock'
 
 describe('InfluxDB', () => {
   afterEach(() => {
@@ -43,20 +44,24 @@ describe('InfluxDB', () => {
     const query = 'select *'
     client.query(query)
 
-    expect(queryStub.calledOnceWith(query, database, 'sql')).to.be.true
+    // expect(queryStub.calledOnceWith(query, database, 'sql')).to.be.true
+    expect(queryStub.calledOnceWith(query, database)).to.be.true
     queryStub.resetHistory()
 
     client.query(query, 'another')
-    expect(queryStub.calledOnceWith(query, 'another', 'sql')).to.be.true
+    // expect(queryStub.calledOnceWith(query, 'another', 'sql')).to.be.true
+    expect(queryStub.calledOnceWith(query, 'another')).to.be.true
 
     // queryPoints
     client.queryPoints(query)
 
-    expect(queryPointsStub.calledOnceWith(query, database, 'sql')).to.be.true
+    // expect(queryPointsStub.calledOnceWith(query, database, 'sql')).to.be.true
+    expect(queryPointsStub.calledOnceWith(query, database)).to.be.true
     queryPointsStub.resetHistory()
 
     client.queryPoints(query, 'another')
-    expect(queryPointsStub.calledOnceWith(query, 'another', 'sql')).to.be.true
+    // expect(queryPointsStub.calledOnceWith(query, 'another', 'sql')).to.be.true
+    expect(queryPointsStub.calledOnceWith(query, 'another')).to.be.true
   })
 
   it('throws when no database provided', async () => {
@@ -413,6 +418,180 @@ at 'ClientOptions.database'
           precision: 'us' as WritePrecision,
           gzipThreshold: 128,
         } as WriteOptions,
+      })
+    })
+  })
+  describe('options handling', () => {
+    const DATABASE = 'TEST_DATABASE'
+    it('merges write options', () => {
+      const client = new InfluxDBClient({
+        host: 'http://localhost:8086',
+        token: 'TEST_TOKEN',
+        writeOptions: {
+          gzipThreshold: 1000,
+          headers: {
+            terminate: 'tomorrow',
+            'channel-preference': 'irish',
+          },
+        },
+      })
+      const options = client['_mergeWriteOptions']({
+        precision: 's',
+        headers: {
+          hunter: 'H. Hancock',
+        },
+      })
+      expect(options).to.deep.equal({
+        gzipThreshold: 1000,
+        headers: {
+          terminate: 'tomorrow',
+          'channel-preference': 'irish',
+          hunter: 'H. Hancock',
+        },
+        precision: 's',
+      })
+    })
+    it('merges write options with preference for method arg', async () => {
+      const client = new InfluxDBClient({
+        host: 'http://localhost:8086',
+        token: 'TEST_TOKEN',
+        headers: {
+          preserve: '2d',
+        },
+        writeOptions: {
+          gzipThreshold: 1000,
+          headers: {
+            terminate: 'tomorrow',
+            'channel-preference': 'irish',
+            hunter: 'maori',
+          },
+        },
+      })
+      const options = client['_mergeWriteOptions']({
+        precision: 's',
+        headers: {
+          terminate: '12h',
+          hunter: 'H. Hancock',
+        },
+        gzipThreshold: 500,
+      })
+      expect(options).to.deep.equal({
+        gzipThreshold: 500,
+        headers: {
+          terminate: '12h',
+          'channel-preference': 'irish',
+          hunter: 'H. Hancock',
+        },
+        precision: 's',
+      })
+    })
+    it('uses all header options on write', async () => {
+      let extra: any
+      let special: any
+      let oneOff: any
+      nock('http://test:8086')
+        .post(`/api/v2/write?bucket=${DATABASE}&precision=ns`)
+        .reply(
+          204,
+          function (_uri, _body, callback) {
+            extra = this.req.headers['extra']
+            special = this.req.headers['special']
+            oneOff = this.req.headers['one-off']
+            callback(null, '..')
+          },
+          {
+            'content-type': 'application/csv',
+          }
+        )
+        .persist()
+      const client = new InfluxDBClient({
+        host: 'http://test:8086',
+        token: 'TEST_TOKEN',
+        database: DATABASE,
+        headers: {
+          extra: 'yes',
+        },
+        writeOptions: {
+          headers: {
+            special: 'super',
+          },
+        },
+      })
+      await client.write('lpdata', undefined, undefined, {
+        headers: {
+          'one-off': 'top of the league',
+        },
+      })
+      expect(extra).to.equal('yes')
+      expect(special).to.equal('super')
+      expect(oneOff).to.equal('top of the league')
+    })
+    it('merges query options', () => {
+      const client = new InfluxDBClient({
+        host: 'http://localhost:8086',
+        token: 'TEST_TOKEN',
+        queryOptions: {
+          headers: {
+            terminate: 'tomorrow',
+            'channel-preference': 'irish',
+          },
+          type: 'influxql',
+        },
+      })
+      const options = client['_mergeQueryOptions']({
+        headers: {
+          hunter: 'H. Hancock',
+        },
+        params: {
+          location: 'tower1',
+        },
+      })
+      expect(options).to.deep.equal({
+        type: 'influxql',
+        headers: {
+          terminate: 'tomorrow',
+          'channel-preference': 'irish',
+          hunter: 'H. Hancock',
+        },
+        params: {
+          location: 'tower1',
+        },
+      })
+    })
+    it('merges query options with preference for method arg', async () => {
+      const client = new InfluxDBClient({
+        host: 'http://localhost:8086',
+        token: 'TEST_TOKEN',
+        queryOptions: {
+          headers: {
+            terminate: 'tomorrow',
+            'channel-preference': 'irish',
+          },
+          type: 'influxql',
+          params: {
+            location: 'tower1',
+          },
+        },
+      })
+      const options = client['_mergeQueryOptions']({
+        headers: {
+          hunter: 'H. Hancock',
+          terminate: '12h',
+        },
+        params: {
+          location: 'well99',
+        },
+      })
+      expect(options).to.deep.equal({
+        type: 'influxql',
+        headers: {
+          terminate: '12h',
+          'channel-preference': 'irish',
+          hunter: 'H. Hancock',
+        },
+        params: {
+          location: 'well99',
+        },
       })
     })
   })

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -594,5 +594,62 @@ at 'ClientOptions.database'
         },
       })
     })
+    it('merges undefined options in method', async () => {
+      const client = new InfluxDBClient({
+        host: 'http://localhost:8086',
+        token: 'TEST_TOKEN',
+        queryOptions: {
+          headers: {
+            terminate: 'tomorrow',
+            'channel-preference': 'irish',
+          },
+          params: {
+            location: 'tower1',
+          },
+        },
+      })
+      const options = client['_mergeQueryOptions'](undefined)
+      expect(options).to.deep.equal({
+        headers: {
+          terminate: 'tomorrow',
+          'channel-preference': 'irish',
+        },
+        params: {
+          location: 'tower1',
+        },
+      })
+    })
+    it('merges undefined options in client options', async () => {
+      const client = new InfluxDBClient({
+        host: 'http://localhost:8086',
+        token: 'TEST_TOKEN',
+      })
+      const options = client['_mergeQueryOptions']({
+        headers: {
+          terminate: 'tomorrow',
+          'channel-preference': 'irish',
+        },
+        params: {
+          location: 'tower1',
+        },
+      })
+      expect(options).to.deep.equal({
+        headers: {
+          terminate: 'tomorrow',
+          'channel-preference': 'irish',
+        },
+        params: {
+          location: 'tower1',
+        },
+      })
+    })
+    it('handles undefined query options', async () => {
+      const client = new InfluxDBClient({
+        host: 'http://localhost:8086',
+        token: 'TEST_TOKEN',
+      })
+      const options = client['_mergeQueryOptions'](undefined)
+      expect(options).to.deep.equal({headers: {}, params: {}})
+    })
   })
 })

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -44,23 +44,19 @@ describe('InfluxDB', () => {
     const query = 'select *'
     client.query(query)
 
-    // expect(queryStub.calledOnceWith(query, database, 'sql')).to.be.true
     expect(queryStub.calledOnceWith(query, database)).to.be.true
     queryStub.resetHistory()
 
     client.query(query, 'another')
-    // expect(queryStub.calledOnceWith(query, 'another', 'sql')).to.be.true
     expect(queryStub.calledOnceWith(query, 'another')).to.be.true
 
     // queryPoints
     client.queryPoints(query)
 
-    // expect(queryPointsStub.calledOnceWith(query, database, 'sql')).to.be.true
     expect(queryPointsStub.calledOnceWith(query, database)).to.be.true
     queryPointsStub.resetHistory()
 
     client.queryPoints(query, 'another')
-    // expect(queryPointsStub.calledOnceWith(query, 'another', 'sql')).to.be.true
     expect(queryPointsStub.calledOnceWith(query, 'another')).to.be.true
   })
 

--- a/packages/client/test/unit/Query.test.ts
+++ b/packages/client/test/unit/Query.test.ts
@@ -81,6 +81,14 @@ describe('Query', () => {
       allParamsMatched(query, queryParams)
     }).to.throw('No parameter matching $_name provided in the query params map')
   })
+  it('ignores params for query without params', () => {
+    const query = `SELECT a, b, c FROM my_table WHERE a = '123' AND c='chat'`
+    expect(queryHasParams(query)).to.be.false
+    const queryParams: Record<string, QParamType> = {}
+    queryParams['b'] = 42
+    queryParams['c'] = 'Zaphrod'
+    expect(allParamsMatched(query, queryParams)).to.be.true
+  })
   it('sets header metadata in request', async () => {
     const options: ConnectionOptions = {
       host: 'http://localhost:8086',

--- a/packages/client/test/unit/Query.test.ts
+++ b/packages/client/test/unit/Query.test.ts
@@ -63,23 +63,23 @@ describe('Query', () => {
     expect(ticketDecode).to.deep.equal(ticketData)
   })
   it('matches all params', () => {
-    const query = 'SELECT a, b, c FROM my_table WHERE id = $id AND name = $name'
+    const query = 'SELECT a, b, c FROM my_table WHERE id = $id AND name=$_name'
     expect(queryHasParams('select * ')).to.be.false
     expect(queryHasParams(query)).to.be.true
     const queryParams: Record<string, QParamType> = {}
     queryParams['id'] = 42
-    queryParams['name'] = 'Zaphrod'
+    queryParams['_name'] = 'Zaphrod'
     expect(allParamsMatched(query, queryParams)).to.be.true
   })
   it('throws error on missing param', () => {
-    const query = 'SELECT a, b, c FROM my_table WHERE id = $id AND name = $name'
+    const query = 'SELECT a, b, c FROM my_table WHERE id = $id AND name=$_name'
     expect(queryHasParams(query)).to.be.true
     const queryParams: Record<string, QParamType> = {}
     queryParams['id'] = 42
-    queryParams['key'] = 'Zaphrod'
+    queryParams['_key'] = 'Zaphrod'
     expect(() => {
       allParamsMatched(query, queryParams)
-    }).to.throw('No parameter matching  $name provided in the query params map')
+    }).to.throw('No parameter matching $_name provided in the query params map')
   })
   it('sets header metadata in request', async () => {
     const options: ConnectionOptions = {

--- a/packages/client/test/unit/Query.test.ts
+++ b/packages/client/test/unit/Query.test.ts
@@ -1,11 +1,10 @@
 import {expect} from 'chai'
 import QueryApiImpl, {TicketDataType} from '../../src/impl/QueryApiImpl'
-import {ConnectionOptions} from '../../src/options'
+import {ConnectionOptions, DEFAULT_QueryOptions} from '../../src/options'
 import {Ticket} from '../../src/generated/flight/Flight'
 import {QParamType} from '../../src/QueryApi'
 import {allParamsMatched, queryHasParams} from '../../src/util/sql'
 import {RpcMetadata} from '@protobuf-ts/runtime-rpc'
-import {DEFAULT_QueryOptions} from '@influxdata/influxdb3-client-browser'
 
 const testSQLTicket = {
   db: 'TestDB',

--- a/packages/client/test/unit/Query.test.ts
+++ b/packages/client/test/unit/Query.test.ts
@@ -4,7 +4,7 @@ import {ConnectionOptions} from '../../src/options'
 import {Ticket} from '../../src/generated/flight/Flight'
 import {QParamType} from '../../src/QueryApi'
 import {allParamsMatched, queryHasParams} from '../../src/util/sql'
-import { RpcMetadata } from "@protobuf-ts/runtime-rpc";
+import {RpcMetadata} from '@protobuf-ts/runtime-rpc'
 
 const testSQLTicket = {
   db: 'TestDB',
@@ -66,17 +66,17 @@ describe('Query', () => {
     const query = 'SELECT a, b, c FROM my_table WHERE id = $id AND name = $name'
     expect(queryHasParams('select * ')).to.be.false
     expect(queryHasParams(query)).to.be.true
-    const queryParams: Map<string, QParamType> = new Map<string, QParamType>()
-    queryParams.set('id', 42)
-    queryParams.set('name', 'Zaphrod')
+    const queryParams: Record<string, QParamType> = {}
+    queryParams['id'] = 42
+    queryParams['name'] = 'Zaphrod'
     expect(allParamsMatched(query, queryParams)).to.be.true
   })
   it('throws error on missing param', () => {
     const query = 'SELECT a, b, c FROM my_table WHERE id = $id AND name = $name'
     expect(queryHasParams(query)).to.be.true
-    const queryParams: Map<string, QParamType> = new Map<string, QParamType>()
-    queryParams.set('id', 42)
-    queryParams.set('key', 'Zaphrod')
+    const queryParams: Record<string, QParamType> = {}
+    queryParams['id'] = 42
+    queryParams['key'] = 'Zaphrod'
     expect(() => {
       allParamsMatched(query, queryParams)
     }).to.throw('No parameter matching  $name provided in the query params map')

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -231,13 +231,18 @@ describe('Write', () => {
     })
     it('sends custom http header', async () => {
       useSubject({
-        headers: {authorization: 'Token customToken'},
+        headers: {
+          authorization: 'Token customToken',
+          'channel-lane': 'reserved',
+        },
       })
       let authorization: any
+      let channelLane: string = ''
       nock(clientOptions.host)
         .post(WRITE_PATH_NS)
         .reply(function (_uri, _requestBody) {
           authorization = this.req.headers.authorization
+          channelLane = this.req.headers['channel-lane']
           return [204, '', {}]
         })
         .persist()
@@ -248,6 +253,10 @@ describe('Write', () => {
       expect(logs.error).has.length(0)
       expect(logs.warn).has.length(0)
       expect(authorization).equals(`Token customToken`)
+      expect(channelLane).equals('reserved')
+    })
+    it('sends custom header from client config', async () => {
+      // Todo -
     })
   })
 })

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -237,7 +237,7 @@ describe('Write', () => {
         },
       })
       let authorization: any
-      let channelLane: string = ''
+      let channelLane = ''
       nock(clientOptions.host)
         .post(WRITE_PATH_NS)
         .reply(function (_uri, _requestBody) {

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -256,7 +256,35 @@ describe('Write', () => {
       expect(channelLane).equals('reserved')
     })
     it('sends custom header from client config', async () => {
-      // Todo -
+      subject = new InfluxDBClient({
+        ...clientOptions,
+        headers: {
+          universal: 'substance',
+        },
+        writeOptions: {
+          headers: {
+            particular: 'attribute',
+          },
+        },
+      })
+      let universal: any
+      let particular: any
+      nock(clientOptions.host)
+        .post(WRITE_PATH_NS)
+        .reply(function (_uri, _requestBody) {
+          universal = this.req.headers.universal
+          particular = this.req.headers.particular
+          return [204, '', {}]
+        })
+        .persist()
+      await subject.write(
+        Point.measurement('test').setFloatField('value', 1),
+        DATABASE
+      )
+      expect(logs.error).has.length(0)
+      expect(logs.warn).has.length(0)
+      expect(universal).equals('substance')
+      expect(particular).equals('attribute')
     })
   })
 })


### PR DESCRIPTION
## Proposed Changes
   * Wrap extra query arguments into a QueryOptions structure
   * Add custom headers to queries
   * On merge of option structures before using transport calls - instead of overwriting values, merge them from...
      * `client_options.headers`
      * `client_options.writeOptions` or `client_options.queryOptions`
      * options arguments passed in `query` or `write` method calls 
   * when `client_options.queryOptions` are defined in the client constructor, these become default when making a query without adding `QueryOptions` to the query call.  This makes it possible for example to define `influxql` as a default queryType for all calls (e,g `ClientOptions{ ... queryOptions:{ type: 'influxql' } }`), and then to not have to add `QueryOptions { type: 'influxql'}` to each call.
   * Update current examples to use `QueryOptions`
   * For tests adds a `MockService` and `TestServer` based on `Flight.gRPC.server` which can be generated in scripts.
   * Update documentation

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x]  Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
