### PR TITLE
feat: adds correct user-agent information header to calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.9.0 [unreleased]
 
+### Features
+
+1. [319](https://github.com/InfluxCommunity/influxdb3-js/pull/319): Adds standard `user-agent` header to calls.
+
 ## 0.8.0 [2024-04-16]
 
 ### Breaking Changes

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -8,7 +8,7 @@ import {RpcMetadata, RpcOptions} from '@protobuf-ts/runtime-rpc'
 import {impl} from './implSelector'
 import {PointFieldType, PointValues} from '../PointValues'
 import {allParamsMatched, queryHasParams} from '../util/sql'
-import {CLIENT_LIB_VERSION} from './version'
+import {CLIENT_LIB_USER_AGENT} from './version'
 
 export type TicketDataType = {
   database: string
@@ -59,7 +59,7 @@ export default class QueryApiImpl implements QueryApi {
 
   prepareMetadata(headers?: Record<string, string>): RpcMetadata {
     const meta: RpcMetadata = {
-      'User-Agent': `influxdb-client-js/${CLIENT_LIB_VERSION}`,
+      'User-Agent': CLIENT_LIB_USER_AGENT,
       ...this._defaultHeaders,
       ...headers,
     }

--- a/packages/client/src/impl/node/NodeHttpTransport.ts
+++ b/packages/client/src/impl/node/NodeHttpTransport.ts
@@ -12,7 +12,7 @@ import {
 } from '../../results'
 import zlib from 'zlib'
 import completeCommunicationObserver from '../completeCommunicationObserver'
-import {CLIENT_LIB_VERSION} from '../version'
+import {CLIENT_LIB_USER_AGENT} from '../version'
 import {Log} from '../../util/logger'
 import {pipeline, Readable} from 'stream'
 import {ConnectionOptions} from '../../options'
@@ -107,7 +107,7 @@ export class NodeHttpTransport implements Transport {
       )
     }
     this._headers = {
-      'User-Agent': `influxdb-client-js/${CLIENT_LIB_VERSION}`,
+      'User-Agent': CLIENT_LIB_USER_AGENT,
       ...connectionOptions.headers,
     }
     if (proxyUrl) {

--- a/packages/client/src/impl/version.ts
+++ b/packages/client/src/impl/version.ts
@@ -1,1 +1,2 @@
 export const CLIENT_LIB_VERSION = '0.8.0'
+export const CLIENT_LIB_USER_AGENT = `influxdb3-js/${CLIENT_LIB_VERSION}`

--- a/packages/client/test/unit/Query.test.ts
+++ b/packages/client/test/unit/Query.test.ts
@@ -5,6 +5,7 @@ import {Ticket} from '../../src/generated/flight/Flight'
 import {QParamType} from '../../src/QueryApi'
 import {allParamsMatched, queryHasParams} from '../../src/util/sql'
 import {RpcMetadata} from '@protobuf-ts/runtime-rpc'
+import {CLIENT_LIB_VERSION} from '../../src/impl/version'
 
 const testSQLTicket = {
   db: 'TestDB',
@@ -132,6 +133,15 @@ describe('Query', () => {
         reg: 'CX',
       },
     })
+  })
+  it('has correct default headers', async () => {
+    const qApi = new QueryApiImpl({
+      host: 'http://localost:8086',
+      token: 'TEST_TOKEN',
+    } as ConnectionOptions)
+    const meta: RpcMetadata = qApi.prepareMetadata()
+    expect(meta['User-Agent']).to.equal(`influxdb3-js/${CLIENT_LIB_VERSION}`)
+    expect(meta['authorization']).to.equal('Bearer TEST_TOKEN')
   })
   it('sets header metadata in request', async () => {
     const options: ConnectionOptions = {

--- a/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -213,7 +213,7 @@ describe('NodeHttpTransport', () => {
             }
             context.matchHeader(
               'User-Agent',
-              `influxdb-client-js/${CLIENT_LIB_VERSION}`
+              `influxdb3-js/${CLIENT_LIB_VERSION}`
             )
             let cancellable: any
             new NodeHttpTransport({
@@ -748,7 +748,7 @@ describe('NodeHttpTransport', () => {
           }
           context.matchHeader(
             'User-Agent',
-            `influxdb-client-js/${CLIENT_LIB_VERSION}`
+            `influxdb3-js/${CLIENT_LIB_VERSION}`
           )
           const transport = new NodeHttpTransport({
             ...extras,


### PR DESCRIPTION
Closes #

## Proposed Changes

* Default Node Rest `user-agent` header updated to `influxdb3-js/<version>`
* Same `user-agent` header added to gRPC
* Tests updated to cover these changes


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
