### PR TITLE
feat: propagate HTTP headers to HttpError type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.10.0 [unreleased]
 
+### Features
+
+1. [369](https://github.com/InfluxCommunity/influxdb3-js/pull/369): Propagates headers from HTTP response to HttpError when an error is returned from the server.
+
 ## 0.9.0 [2024-06-24]
 
 ### Features

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,7 @@
 ## Basic Example
 
 - [IOxExample](./src/index.ts) - How to use write and query data from InfluxDB IOx
+- [IOxRetryExample](./src/writeRetry.ts) - How to use write and then retry if the server returns status `429 - Too many requests` or `503 - Temporarily unavailable`.  
 
 ## prerequisites
 
@@ -26,7 +27,14 @@ INFLUX_DATABASE="<database>"
 INFLUX_TOKEN="<token>"
 ```
 
-### Run example
+### Run examples
+
+#### Basic
 
 - run `yarn install`
 - run `yarn dev`
+
+#### Write Retry
+ 
+- run `yarn install`
+- run `yarn retry`

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -35,6 +35,6 @@ INFLUX_TOKEN="<token>"
 - run `yarn dev`
 
 #### Write Retry
- 
+
 - run `yarn install`
 - run `yarn retry`

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "dev": "ts-node -r dotenv/config ./src/index.ts"
+    "dev": "ts-node -r dotenv/config ./src/index.ts",
+    "retry": "ts-node -r dotenv/config src/writeRetry.ts"
   },
   "dependencies": {
     "@influxdata/influxdb3-client": "link:../../packages/client"

--- a/examples/basic/src/writeRetry.ts
+++ b/examples/basic/src/writeRetry.ts
@@ -18,7 +18,7 @@ async function main() {
   const now = new Date()
   for (let i = 100000; i > -1; i--) {
     const d: Date = new Date(now.getTime() - 100 * i)
-    points[i] = Datum.RandomDatum('demoR').toPoint(d)
+    points[i] = UserMemUsage.RandomUserMemUsage().toPoint(d)
   }
   await writeData(client, points, database, 1)
 }
@@ -104,53 +104,55 @@ const getEnv = (variableName: string): string =>
   process.env[variableName] ??
   throwReturn(new Error(`missing ${variableName} environment variable`))
 
-class Datum {
+class UserMemUsage {
   name: string
   location: string
-  fval: number
-  ival: number
-  sval: string
+  pct: number
+  procCt: number
+  state: string
 
   constructor(
     name: string,
     location: string, // as tag
-    fval: number,
-    ival: number, // as integer
-    sval: string
+    pct: number,
+    procCt: number, // as integer
+    state: string
   ) {
     this.name = name
     this.location = location
-    this.fval = fval
-    this.ival = ival
-    this.sval = sval
+    this.pct = pct
+    this.procCt = procCt
+    this.state = state
   }
 
   static dieRoll(): number {
     return Math.floor(Math.random() * 6) + 1
   }
 
-  static RandomDatum(
-    name = 'random',
+  static RandomUserMemUsage(
+    name = 'userMem',
     location = 'hic',
-    svals = ['feles', 'canus', 'mus', 'equus', 'bos']
-  ): Datum {
-    return new Datum(
+    states = ['OK', 'WARNING', 'EXCEEDED', 'CRITICAL', 'ERROR']
+  ): UserMemUsage {
+    return new UserMemUsage(
       name,
       location,
       Math.random() * 100,
       this.dieRoll() + this.dieRoll() + this.dieRoll(),
-      svals[Math.floor(Math.random() * svals.length)]
+      states[Math.floor(Math.random() * states.length)]
     )
   }
 
   toPoint(date: Date): Point {
     return Point.measurement(this.name)
       .setTag('location', this.location)
-      .setFloatField('fval', this.fval)
-      .setIntegerField('ival', this.ival)
-      .setStringField('sval', this.sval)
+      .setFloatField('percent', this.pct)
+      .setIntegerField('processCount', this.procCt)
+      .setStringField('state', this.state)
       .setTimestamp(date)
   }
 }
 
-main()
+main().then(() => {
+  console.log('DONE')
+})

--- a/examples/basic/src/writeRetry.ts
+++ b/examples/basic/src/writeRetry.ts
@@ -1,0 +1,156 @@
+import {InfluxDBClient, Point, HttpError} from '@influxdata/influxdb3-client'
+
+/**
+ * This example seeks to exceed the write limit of a standard unpaid
+ * influxdb account.  Run it from the command line a couple of times in
+ * succession (e.g. `yarn retry`).  The first run should succeed, but
+ * the second run should exceed the max write limit and the server should
+ * return 429 with a `retry-after` header.
+ */
+async function main() {
+  const host = getEnv('INFLUX_HOST')
+  const token = getEnv('INFLUX_TOKEN')
+  const database = getEnv('INFLUX_DATABASE')
+
+  const client = new InfluxDBClient({host, token})
+
+  const points: Point[] = []
+  const now = new Date()
+  for (let i = 100000; i > -1; i--) {
+    const d: Date = new Date(now.getTime() - 100 * i)
+    points[i] = Datum.RandomDatum('demoR').toPoint(d)
+  }
+  await writeData(client, points, database, 1)
+}
+
+/**
+ * Returns the retry interval in milliseconds
+ *
+ * @param retry string or string[] from `retry-after` header
+ */
+function getRetryInterval(retry: string | string[]): number {
+  const token = retry.toString()
+  let result: number = parseInt(token)
+  if (isNaN(result)) {
+    const now: Date = new Date()
+    const exp: Date = new Date(token)
+    if (isNaN(exp.valueOf())) {
+      throw new Error(`Failed to parse retry value: ${retry}`)
+    }
+    result = exp.getTime() - now.getTime()
+  } else {
+    result *= 1000
+  }
+  return result
+}
+
+let initialRetry: number
+
+/**
+ * Helper function to leverage `retry-after` in the event a HttpError
+ * is returned.
+ *
+ * @param client an InfluxDBClient instance
+ * @param data data to be written
+ * @param database target database
+ * @param retryCount number of times to retry writing data
+ */
+async function writeData(
+  client: InfluxDBClient,
+  data: Point | Point[],
+  database: string,
+  retryCount = 0
+) {
+  if (initialRetry == null) {
+    initialRetry = retryCount
+  }
+  try {
+    await client.write(data, database)
+    console.log(`Write success on try ${1 + initialRetry - retryCount}`)
+  } catch (error: any) {
+    if (
+      error instanceof HttpError &&
+      error.headers &&
+      error?.headers['retry-after']
+    ) {
+      console.log(
+        `WARNING[${new Date()}]: Caught error ${JSON.stringify(error)}`
+      )
+      if (retryCount > 0) {
+        // add an extra second to be sure
+        const interval = getRetryInterval(error?.headers['retry-after']) + 1000
+        console.log(`Retrying in ${interval} ms`)
+        setTimeout(() => {
+          writeData(client, data, database, retryCount - 1)
+        }, interval)
+      } else {
+        console.log(
+          `ERROR[${new Date()}]: Failed to write data after ${initialRetry} attempts.`
+        )
+      }
+    }
+  }
+}
+
+type Defined<T> = Exclude<T, undefined>
+
+/* allows to throw error as expression */
+const throwReturn = <T>(err: Error): Defined<T> => {
+  throw err
+}
+
+/* get environment value or throw error if missing */
+const getEnv = (variableName: string): string =>
+  process.env[variableName] ??
+  throwReturn(new Error(`missing ${variableName} environment variable`))
+
+class Datum {
+  name: string
+  location: string
+  fval: number
+  ival: number
+  sval: string
+
+  constructor(
+    name: string,
+    location: string, // as tag
+    fval: number,
+    ival: number, // as integer
+    sval: string
+  ) {
+    this.name = name
+    this.location = location
+    this.fval = fval
+    this.ival = ival
+    this.sval = sval
+  }
+
+  static dieRoll(): number {
+    return Math.floor(Math.random() * 6) + 1
+  }
+
+  static RandomDatum(
+    name = 'random',
+    location = 'hic',
+    svals = ['feles', 'canus', 'mus', 'equus', 'bos']
+  ): Datum {
+    return new Datum(
+      name,
+      location,
+      Math.random() * 100,
+      this.dieRoll() + this.dieRoll() + this.dieRoll(),
+      svals[Math.floor(Math.random() * svals.length)]
+    )
+  }
+
+  toPoint(date: Date): Point {
+    return Point.measurement(this.name)
+      .setTag('location', this.location)
+      .setFloatField('fval', this.fval)
+      .setIntegerField('ival', this.ival)
+      .setStringField('sval', this.sval)
+      .setTimestamp(date)
+  }
+}
+
+main()

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,3 +1,5 @@
+import {Headers} from './results'
+
 /** IllegalArgumentError is thrown when illegal argument is supplied. */
 export class IllegalArgumentError extends Error {
   /* istanbul ignore next */
@@ -23,6 +25,7 @@ export class HttpError extends Error {
     readonly statusMessage: string | undefined,
     readonly body?: string,
     readonly contentType?: string | undefined | null,
+    readonly headers?: Headers | null,
     message?: string
   ) {
     super()

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -53,9 +53,11 @@ export default class WriteApiImpl implements WriteApi {
     })
 
     let responseStatusCode: number | undefined
+    let headers: Headers
     const callbacks = {
       responseStarted(_headers: Headers, statusCode?: number): void {
         responseStatusCode = statusCode
+        headers = _headers
       },
       error(error: Error): void {
         // ignore informational message about the state of InfluxDB
@@ -84,7 +86,8 @@ export default class WriteApiImpl implements WriteApi {
             responseStatusCode,
             message,
             undefined,
-            '0'
+            '0',
+            headers
           )
           error.message = message
           callbacks.error(error)

--- a/packages/client/src/impl/browser/FetchTransport.ts
+++ b/packages/client/src/impl/browser/FetchTransport.ts
@@ -159,14 +159,16 @@ export default class FetchTransport implements Transport {
           response.status,
           response.statusText,
           undefined,
-          response.headers.get('content-type')
+          response.headers.get('content-type'),
+          getResponseHeaders(response)
         )
       }
       throw new HttpError(
         response.status,
         response.statusText,
         text,
-        response.headers.get('content-type')
+        response.headers.get('content-type'),
+        getResponseHeaders(response)
       )
     }
   }

--- a/packages/client/src/impl/node/NodeHttpTransport.ts
+++ b/packages/client/src/impl/node/NodeHttpTransport.ts
@@ -71,7 +71,7 @@ export class NodeHttpTransport implements Transport {
       protocol: url.protocol,
       hostname: url.hostname,
     }
-    this._contextPath = proxyUrl ? _url : url.path ?? ''
+    this._contextPath = proxyUrl ? _url : (url.path ?? '')
     if (this._contextPath.endsWith('/')) {
       this._contextPath = this._contextPath.substring(
         0,
@@ -350,8 +350,8 @@ export class NodeHttpTransport implements Transport {
             statusCode,
             res.statusMessage,
             body,
-            res.headers['retry-after'],
-            res.headers['content-type']
+            res.headers['content-type'],
+            res.headers
           )
         )
       })

--- a/packages/client/src/impl/node/NodeHttpTransport.ts
+++ b/packages/client/src/impl/node/NodeHttpTransport.ts
@@ -71,7 +71,7 @@ export class NodeHttpTransport implements Transport {
       protocol: url.protocol,
       hostname: url.hostname,
     }
-    this._contextPath = proxyUrl ? _url : (url.path ?? '')
+    this._contextPath = proxyUrl ? _url : url.path ?? ''
     if (this._contextPath.endsWith('/')) {
       this._contextPath = this._contextPath.substring(
         0,

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -287,4 +287,68 @@ describe('Write', () => {
       expect(particular).equals('attribute')
     })
   })
+  describe('propagate error headers', async () => {
+    it('propagates retry header on 429', async () => {
+      const client: InfluxDBClient = new InfluxDBClient({
+        ...clientOptions,
+      })
+      nock(clientOptions.host)
+        .post(WRITE_PATH_NS)
+        .reply(function (_uri, _requestBody) {
+          return [
+            429,
+            '{ message: "see status code"}',
+            {'retry-after': '42', 'content-type': 'application/json'},
+          ]
+        })
+        .persist()
+      try {
+        await client.write(
+          Point.measurement('test').setFloatField('value', 1),
+          DATABASE
+        )
+      } catch (error: any) {
+        expect(error.contentType).equals('application/json')
+        expect(error.statusCode).equals(429)
+        expect(error.headers).is.not.empty
+        expect(error.headers['retry-after']).equals('42')
+        if (!(error instanceof HttpError)) {
+          expect.fail(`caught error which is not HttpError: ${error}`)
+        }
+      }
+    })
+    it('propagates retry on 500', async () => {
+      const client: InfluxDBClient = new InfluxDBClient({
+        ...clientOptions,
+      })
+      const retryDate = new Date(new Date().valueOf() + 600000)
+      nock(clientOptions.host)
+        .post(WRITE_PATH_NS)
+        .reply(function (_uri, _requestBody) {
+          return [
+            500,
+            '{ message: "see status code"}',
+            {
+              'retry-after': retryDate.toISOString(),
+              'content-type': 'application/json',
+            },
+          ]
+        })
+        .persist()
+      try {
+        await client.write(
+          Point.measurement('test').setFloatField('value', 1),
+          DATABASE
+        )
+      } catch (error: any) {
+        expect(error.contentType).equals('application/json')
+        expect(error.statusCode).equals(500)
+        expect(error.headers).is.not.empty
+        expect(retryDate.toISOString()).equals(error.headers['retry-after'])
+        if (!(error instanceof HttpError)) {
+          expect.fail(`caught error which is not HttpError: ${error}`)
+        }
+      }
+    })
+  })
 })

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -317,7 +317,7 @@ describe('Write', () => {
         }
       }
     })
-    it('propagates retry on 500', async () => {
+    it('propagates retry on 503', async () => {
       const client: InfluxDBClient = new InfluxDBClient({
         ...clientOptions,
       })
@@ -326,7 +326,7 @@ describe('Write', () => {
         .post(WRITE_PATH_NS)
         .reply(function (_uri, _requestBody) {
           return [
-            500,
+            503,
             '{ message: "see status code"}',
             {
               'retry-after': retryDate.toISOString(),

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -342,7 +342,7 @@ describe('Write', () => {
         )
       } catch (error: any) {
         expect(error.contentType).equals('application/json')
-        expect(error.statusCode).equals(500)
+        expect(error.statusCode).equals(503)
         expect(error.headers).is.not.empty
         expect(retryDate.toISOString()).equals(error.headers['retry-after'])
         if (!(error instanceof HttpError)) {

--- a/packages/client/test/unit/errors.test.ts
+++ b/packages/client/test/unit/errors.test.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai'
+import * as http from 'http'
 import {
   HttpError,
   RequestTimedOutError,
@@ -29,9 +30,34 @@ describe('errors', () => {
     })
   })
   describe('message property is defined', () => {
-    expect(new HttpError(200, 'OK').message).is.not.empty
-    expect(new IllegalArgumentError('Not OK').message).is.not.empty
-    expect(new RequestTimedOutError().message).is.not.empty
-    expect(new AbortError().message).is.not.empty
+    it('verifies message properties', () => {
+      expect(new HttpError(200, 'OK').message).is.not.empty
+      expect(new IllegalArgumentError('Not OK').message).is.not.empty
+      expect(new RequestTimedOutError().message).is.not.empty
+      expect(new AbortError().message).is.not.empty
+    })
+  })
+  describe('http error values', () => {
+    it('propagate headers', () => {
+      const httpHeaders: http.IncomingHttpHeaders = {
+        'content-type': 'application/json',
+        'retry-after': '42',
+      }
+      const httpError: HttpError = new HttpError(
+        429,
+        'Too Many Requests',
+        undefined,
+        httpHeaders['content-type'],
+        httpHeaders
+      )
+      expect(httpError.headers).is.not.empty
+      expect(httpError.contentType).equals('application/json')
+      expect(httpError.statusMessage).equals('Too Many Requests')
+      if (httpError.headers) {
+        expect(httpError.headers['retry-after']).equals('42')
+      } else {
+        expect.fail('httpError.headers should be defined')
+      }
+    })
   })
 })

--- a/packages/client/test/unit/impl/browser/emulateBrowser.ts
+++ b/packages/client/test/unit/impl/browser/emulateBrowser.ts
@@ -113,7 +113,9 @@ export function emulateFetchApi(
   function fetch(url: string, options: any): Promise<any> {
     if (onRequest) onRequest(options)
     return url.endsWith('error')
-      ? Promise.reject(new HttpError(500, undefined, undefined, undefined, undefined, url))
+      ? Promise.reject(
+          new HttpError(500, undefined, undefined, undefined, undefined, url)
+        )
       : Promise.resolve(createResponse(spec))
   }
   class TextEncoder {

--- a/packages/client/test/unit/impl/browser/emulateBrowser.ts
+++ b/packages/client/test/unit/impl/browser/emulateBrowser.ts
@@ -113,7 +113,7 @@ export function emulateFetchApi(
   function fetch(url: string, options: any): Promise<any> {
     if (onRequest) onRequest(options)
     return url.endsWith('error')
-      ? Promise.reject(new HttpError(500, undefined, undefined, undefined, url))
+      ? Promise.reject(new HttpError(500, undefined, undefined, undefined, undefined, url))
       : Promise.resolve(createResponse(spec))
   }
   class TextEncoder {


### PR DESCRIPTION
Closes #357

## Proposed Changes

_Briefly describe your proposed changes:_
  * Update `HttpError` to include a `headers` type
  * In transport implementations, add headers from HTTP response to `HttpError` when an error is encountered.
  * Provide an example showing how to work with `retry-after` header when encountering HTTP `429` or `503`
  * Update existing tests
  * Add new appropriate tests

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
