### PR TITLE
fix: handle Edge errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [369](https://github.com/InfluxCommunity/influxdb3-js/pull/369): Propagates headers from HTTP response to HttpError when an error is returned from the server.
+1. [376](https://github.com/InfluxCommunity/influxdb3-js/pull/376): Handle InfluxDB Edge (OSS) errors better.
 
 ## 0.9.0 [2024-06-24]
 

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -39,13 +39,13 @@ export class HttpError extends Error {
           this.message = this.json.message
           this.code = this.json.code
           if (!this.message) {
-            interface edgeBody {
+            interface EdgeBody {
               error?: string;
               data?: {
                 error_message: string;
               }
             }
-            const eb: edgeBody = this.json as edgeBody
+            const eb: EdgeBody = this.json as EdgeBody
             if (eb.data?.error_message) {
               this.message = eb.data.error_message
             } else if (eb.error) {

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -33,16 +33,17 @@ export class HttpError extends Error {
     if (message) {
       this.message = message
     } else if (body) {
-      if (contentType?.startsWith('application/json') || !contentType) { // Edge may not set Content-Type header
+      // Edge may not set Content-Type header
+      if (contentType?.startsWith('application/json') || !contentType) {
         try {
           this.json = JSON.parse(body)
           this.message = this.json.message
           this.code = this.json.code
           if (!this.message) {
             interface EdgeBody {
-              error?: string;
+              error?: string
               data?: {
-                error_message: string;
+                error_message?: string
               }
             }
             const eb: EdgeBody = this.json as EdgeBody

--- a/packages/client/test/unit/errors.test.ts
+++ b/packages/client/test/unit/errors.test.ts
@@ -37,6 +37,37 @@ describe('errors', () => {
       expect(new AbortError().message).is.not.empty
     })
   })
+  describe('HttpError message property is correct', () => {
+    it('verifies Cloud error message', () => {
+      expect(
+        new HttpError(
+          400,
+          'Bad Request',
+          '{"message": "parsing failed for write_lp endpoint"}'
+        ).message
+      ).equals('parsing failed for write_lp endpoint')
+    })
+    it('verifies Edge error without detail message', () => {
+      expect(
+        new HttpError(
+          400,
+          'Bad Request',
+          '{"error": "parsing failed for write_lp endpoint"}'
+        ).message
+      ).equals('parsing failed for write_lp endpoint')
+    })
+    it('verifies Edge error with detail message', () => {
+      expect(
+        new HttpError(
+          400,
+          'Bad Request',
+          '{"error": "parsing failed for write_lp endpoint", "data": {"error_message": "invalid field value in line protocol for field \'value\' on line 0"}}' // Edge
+        ).message
+      ).equals(
+        "invalid field value in line protocol for field 'value' on line 0"
+      )
+    })
+  })
   describe('http error values', () => {
     it('propagate headers', () => {
       const httpHeaders: http.IncomingHttpHeaders = {


### PR DESCRIPTION
## Proposed Changes

Extends error response processing to handle Edge (OSS) errors as well. It sets `Error.message` value from either `message` (Cloud) or `data.error_message` / `error` (Edge) element value in the response body when an InfluxDB error occurs.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
