### PR TITLE
fix: add Edge authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [369](https://github.com/InfluxCommunity/influxdb3-js/pull/369): Propagates headers from HTTP response to HttpError when an error is returned from the server.
 1. [376](https://github.com/InfluxCommunity/influxdb3-js/pull/376): Handle InfluxDB Edge (OSS) errors better.
+1. [377](https://github.com/InfluxCommunity/influxdb3-js/pull/377): Add InfluxDB Edge (OSS) authentication support.
 
 ## 0.9.0 [2024-06-24]
 

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -42,6 +42,7 @@ export default class InfluxDBClient {
    *
    * Supported query parameters:
    *   - token - authentication token (required)
+   *   - authScheme - token authentication scheme. Not set for Cloud access, set to 'Bearer' for Edge.
    *   - database - database (bucket) name
    *   - timeout - I/O timeout
    *   - precision - timestamp precision when writing data
@@ -57,6 +58,7 @@ export default class InfluxDBClient {
    * Supported variables:
    *   - INFLUX_HOST - cloud/server URL (required)
    *   - INFLUX_TOKEN - authentication token (required)
+   *   - INFLUX_AUTH_SCHEME - token authentication scheme. Not set for Cloud access, set to 'Bearer' for Edge.
    *   - INFLUX_TIMEOUT - I/O timeout
    *   - INFLUX_DATABASE - database (bucket) name
    *   - INFLUX_PRECISION - timestamp precision when writing data

--- a/packages/client/src/impl/browser/FetchTransport.ts
+++ b/packages/client/src/impl/browser/FetchTransport.ts
@@ -40,9 +40,10 @@ export default class FetchTransport implements Transport {
       ..._connectionOptions.headers,
     }
     if (this._connectionOptions.token) {
+      const authScheme = this._connectionOptions.authScheme ?? 'Token'
       this._defaultHeaders[
         'Authorization'
-      ] = `Token ${this._connectionOptions.token}`
+      ] = `${authScheme} ${this._connectionOptions.token}`
     }
     this._url = String(this._connectionOptions.host)
     if (this._url.endsWith('/')) {

--- a/packages/client/src/impl/node/NodeHttpTransport.ts
+++ b/packages/client/src/impl/node/NodeHttpTransport.ts
@@ -49,6 +49,7 @@ export class NodeHttpTransport implements Transport {
   ) => http.ClientRequest
   private _contextPath: string
   private _token?: string
+  private _authScheme?: string
   private _headers: Record<string, string>
   /**
    * Creates a node transport using for the client options supplied.
@@ -59,11 +60,13 @@ export class NodeHttpTransport implements Transport {
       host: _url,
       proxyUrl,
       token,
+      authScheme,
       transportOptions,
       ...nodeSupportedOptions
     } = connectionOptions
     const url = parse(proxyUrl || _url)
     this._token = token
+    this._authScheme = authScheme
     this._defaultOptions = {
       ...nodeSupportedOptions,
       ...transportOptions,
@@ -276,7 +279,8 @@ export class NodeHttpTransport implements Transport {
       ...this._headers,
     }
     if (this._token) {
-      headers.authorization = `Token ${this._token}`
+      const authScheme = this._authScheme ?? 'Token'
+      headers.authorization = `${authScheme} ${this._token}`
     }
     const options: {[key: string]: any} = {
       ...this._defaultOptions,

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -9,6 +9,8 @@ export interface ConnectionOptions {
   host: string
   /** authentication token */
   token?: string
+  /** token authentication scheme. Not set for Cloud access, set to 'Bearer' for Edge. */
+  authScheme?: string
   /**
    * socket timeout. 10000 milliseconds by default in node.js. Not applicable in browser (option is ignored).
    * @defaultValue 10000
@@ -190,6 +192,9 @@ export function fromConnectionString(connectionString: string): ClientOptions {
   if (url.searchParams.has('token')) {
     options.token = url.searchParams.get('token') as string
   }
+  if (url.searchParams.has('authScheme')) {
+    options.authScheme = url.searchParams.get('authScheme') as string
+  }
   if (url.searchParams.has('database')) {
     options.database = url.searchParams.get('database') as string
   }
@@ -227,6 +232,9 @@ export function fromEnv(): ClientOptions {
   }
   if (process.env.INFLUX_TOKEN) {
     options.token = process.env.INFLUX_TOKEN.trim()
+  }
+  if (process.env.INFLUX_AUTH_SCHEME) {
+    options.authScheme = process.env.INFLUX_AUTH_SCHEME.trim()
   }
   if (process.env.INFLUX_DATABASE) {
     options.database = process.env.INFLUX_DATABASE.trim()

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -217,6 +217,17 @@ at 'ClientOptions.database'
         token: 'my-token',
       })
     })
+    it('is created with token and auth scheme', () => {
+      expect(
+        (new InfluxDBClient('https://localhost:8086?token=my-token&authScheme=my-scheme') as any)
+          ._options
+      ).to.deep.equal({
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        authScheme: 'my-scheme',
+      })
+    })
     it('is created with token + has whitespaces around (#194)', () => {
       expect(
         (new InfluxDBClient(' https://localhost:8086?token=my-token ') as any)
@@ -310,6 +321,7 @@ at 'ClientOptions.database'
     const clear = () => {
       delete process.env['INFLUX_HOST']
       delete process.env['INFLUX_TOKEN']
+      delete process.env['INFLUX_AUTH_SCHEME']
       delete process.env['INFLUX_DATABASE']
       delete process.env['INFLUX_TIMEOUT']
       delete process.env['INFLUX_PRECISION']
@@ -336,6 +348,18 @@ at 'ClientOptions.database'
         ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
+      })
+    })
+    it('is created with host and token and auth scheme', () => {
+      clear()
+      process.env['INFLUX_HOST'] = 'https://localhost:8086'
+      process.env['INFLUX_TOKEN'] = 'my-token'
+      process.env['INFLUX_AUTH_SCHEME'] = 'my-scheme'
+      expect((new InfluxDBClient() as any)._options).to.deep.equal({
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        authScheme: 'my-scheme',
       })
     })
     it('is created with host and token + has whitespaces around (#194)', () => {

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -219,8 +219,11 @@ at 'ClientOptions.database'
     })
     it('is created with token and auth scheme', () => {
       expect(
-        (new InfluxDBClient('https://localhost:8086?token=my-token&authScheme=my-scheme') as any)
-          ._options
+        (
+          new InfluxDBClient(
+            'https://localhost:8086?token=my-token&authScheme=my-scheme'
+          ) as any
+        )._options
       ).to.deep.equal({
         ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',

--- a/packages/client/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/client/test/unit/impl/browser/FetchTransport.test.ts
@@ -52,6 +52,19 @@ describe('FetchTransport', () => {
       })
       expect(transport._connectionOptions).to.deep.equal(options)
     })
+    it('creates the transport with url and token and auth scheme', () => {
+      const options: ConnectionOptions = {
+        host: 'http://test:8086',
+        token: 'a',
+        authScheme: 'Bearer',
+      }
+      const transport: any = new FetchTransport(options)
+      expect(transport._defaultHeaders).to.deep.equal({
+        'content-type': 'application/json; charset=utf-8',
+        Authorization: 'Bearer a',
+      })
+      expect(transport._connectionOptions).to.deep.equal(options)
+    })
     it('ignore last slash / in url', () => {
       const options: ConnectionOptions = {
         host: 'http://test:8086/',

--- a/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -705,6 +705,12 @@ describe('NodeHttpTransport', () => {
         {},
         {
           token: 'a',
+          expectAuthorizationHeaderValue: 'Token a',
+        },
+        {
+          token: 'a',
+          authScheme: 'Bearer',
+          expectAuthorizationHeaderValue: 'Bearer a',
         },
         {
           headers: {
@@ -744,7 +750,7 @@ describe('NodeHttpTransport', () => {
             ])
             .persist()
           if (extras.token) {
-            context.matchHeader('authorization', `Token ${extras.token}`)
+            context.matchHeader('authorization', extras.expectAuthorizationHeaderValue)
           }
           context.matchHeader(
             'User-Agent',

--- a/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -750,7 +750,10 @@ describe('NodeHttpTransport', () => {
             ])
             .persist()
           if (extras.token) {
-            context.matchHeader('authorization', extras.expectAuthorizationHeaderValue)
+            context.matchHeader(
+              'authorization',
+              extras.expectAuthorizationHeaderValue
+            )
           }
           context.matchHeader(
             'User-Agent',


### PR DESCRIPTION
## Proposed Changes

Adds `authScheme` option to Client initialization (via `ConnectionOptions`, connection string or environment variables) to allow setting token authentication scheme other then the default `"Token"` (used for Cloud). For Edge (OSS), users need to set it to `"Bearer"`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)