### PR TITLE
fix: handle 2xx response for writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.11.0 [unreleased]
 
+### Features
+
+1. [410](https://github.com/InfluxCommunity/influxdb3-js/pull/410): Accepts HTTP responses with 2xx status codes as a success for writes.
+
 ## 0.10.0 [2024-08-12]
 
 ### Features

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -78,10 +78,13 @@ export default class WriteApiImpl implements WriteApi {
       },
       complete(): void {
         // older implementations of transport do not report status code
-        if (responseStatusCode == 204 || responseStatusCode == undefined) {
+        if (
+          responseStatusCode == undefined ||
+          (responseStatusCode >= 200 && responseStatusCode < 300)
+        ) {
           resolve()
         } else {
-          const message = `204 HTTP response status code expected, but ${responseStatusCode} returned`
+          const message = `2xx HTTP response status code expected, but ${responseStatusCode} returned`
           const error = new HttpError(
             responseStatusCode,
             message,

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -202,32 +202,20 @@ describe('Write', () => {
         }
       )
     })
-    it('fails on write response status not being exactly 204', async () => {
-      // required because of https://github.com/influxdata/influxdb-client-js/issues/263
+    it('support 201 Created', async () => {
       useSubject({})
       let authorization: any
       nock(clientOptions.host)
         .post(WRITE_PATH_NS)
         .reply(function (_uri, _requestBody) {
           authorization = this.req.headers.authorization
-          return [200, '', {}]
+          return [201, '', {}]
         })
         .persist()
-      await subject
-        .write('test value=1', DATABASE)
-        .then(() => expect.fail('failure expected'))
-        .catch((e) => {
-          expect(e).to.be.ok
-        })
-      expect(logs.error).has.length(1)
-      expect(logs.error[0][0]).equals('Write to InfluxDB failed.')
-      expect(logs.error[0][1]).instanceOf(HttpError)
-      expect(logs.error[0][1].statusCode).equals(200)
-      expect(logs.error[0][1].message).equals(
-        `204 HTTP response status code expected, but 200 returned`
-      )
-      expect(logs.warn).deep.equals([])
-      expect(authorization).equals(`Token ${clientOptions.token}`)
+      await subject.write('test value=1', DATABASE)
+      expect(logs.error).to.length(0)
+      expect(logs.warn).to.length(0)
+      expect(authorization).equals(`Token a`)
     })
     it('sends custom http header', async () => {
       useSubject({


### PR DESCRIPTION
## Proposed Changes

Handles `2xx` responses for writes. InfluxDB v3 may also return 201 for writes and there is an agreement that all `2xx` should be considered as a success for writes in v3 clients.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
