### PR TITLE
fix: Fix/no unused locals in test generated

### DIFF
--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "resolveJsonModule": true,
-    "lib": ["DOM", "es2018"]
+    "lib": ["DOM", "es2023"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
   "exclude": ["*.js"]

--- a/scripts/generate-flight.js
+++ b/scripts/generate-flight.js
@@ -22,7 +22,7 @@ const packageJsonContent = {
     'generate-protoc': `npx protoc --experimental_allow_proto3_optional --ts_out ./${OUTPUT_DIR}/ --ts_opt optimize_code_size --ts_opt server_grpc1 --proto_path . *.proto`,
   },
   dependencies: {
-    '@protobuf-ts/plugin': '^2.9.0',
+    '@protobuf-ts/plugin': '2.10.0',
   },
   license: 'MIT',
 }

--- a/scripts/generate-flight.js
+++ b/scripts/generate-flight.js
@@ -19,10 +19,10 @@ const OUTPUT_DIR = 'out/flight'
 const packageJsonContent = {
   scripts: {
     protoc: 'protoc',
-    'generate-protoc': `npx protoc --experimental_allow_proto3_optional --ts_out ./${OUTPUT_DIR}/ --ts_opt optimize_code_size --ts_opt server_grpc1 --proto_path . *.proto`,
+    'generate-protoc': `npx protoc --experimental_allow_proto3_optional --ts_out ./${OUTPUT_DIR}/ --ts_opt optimize_code_size --ts_opt server_grpc1 --ts_opt ts_nocheck --proto_path . *.proto`,
   },
   dependencies: {
-    '@protobuf-ts/plugin': '2.10.0',
+    '@protobuf-ts/plugin': '^2.11.0',
   },
   license: 'MIT',
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "lib": ["es2018"],
+    "target": "es2023",
+    "lib": ["es2023"],
     "allowJs": false,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Proposed Changes

Update target ecmascript base to `es2023` and use those libraries.  

In `generate-flight.js` add the option `--ts_opt ts_nocheck` to prevent typescript checks of generated code. 

The latest version `2.11.0` generates code that violates the tsconfig rule `"noUnusedLocals": true,` and causes tests to fail.  

for example: 

```
> @influxdata/influxdb3-client
$ yarn run lint:ci && yarn run test:all --exit --reporter mocha-junit-reporter --reporter-options mochaFile=../../reports/core_mocha/test-results.xml
$ yarn run lint --format junit --output-file ../../reports/core_eslint/eslint.xml
$ eslint src/**/*.ts test/**/*.ts --format junit --output-file ../../reports/core_eslint/eslint.xml
$ mocha 'test/**/*.test.ts' --exit --exit --reporter mocha-junit-reporter --reporter-options mochaFile=../../reports/core_mocha/test-results.xml

 Exception during run: test/generated/flight/Flight.ts:2114:27 - error TS6133: 'wireType' is declared but its value is never read.

2114             let [fieldNo, wireType] = reader.tag();
                               ~~~~~~~~
test/generated/flight/Flight.ts:2181:27 - error TS6133: 'wireType' is declared but its value is never read.

2181             let [fieldNo, wireType] = reader.tag();
                               ~~~~~~~~
test/generated/flight/Flight.ts:2333:27 - error TS6133: 'wireType' is declared but its value is never read.

2333             let [fieldNo, wireType] = reader.tag();
                               ~~~~~~~~

error Command failed with exit code 1.
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [n/a] CHANGELOG.md updated
- [x] Rebased/mergeable
- [n/a] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
