### PR TITLE
feat: grpc header support

### DIFF
--- a/examples/basic/src/clientWithGrpcOptions.ts
+++ b/examples/basic/src/clientWithGrpcOptions.ts
@@ -1,0 +1,60 @@
+import {InfluxDBClient} from '@influxdata/influxdb3-client'
+
+/*
+This example shows the ways in which grpc options can be defined
+when the client is instantiated.
+
+See the @grpc/grpc-js dependency for valid option strings
+*/
+
+async function main() {
+  let client: InfluxDBClient
+
+  // declare grpcOptions directly in client options
+  client = new InfluxDBClient({
+    host: 'http://localhost:8086',
+    token: 'my-token',
+    grpcOptions: {
+      'grpc.max_receive_message_length': 1024 * 1024 * 5,
+      'grpc.max_send_message_length': 65536,
+    },
+  })
+  console.log(`peek options ${JSON.stringify(client['_options'])}`)
+  await client.close()
+
+  // declare grpcOptions as a part of queryOptions
+  client = new InfluxDBClient({
+    host: 'http://localhost:8086',
+    token: 'my-token',
+    queryOptions: {
+      grpcOptions: {
+        'grpc.max_receive_message_length': 1024 * 1024 * 10,
+        'grpc.max_send_message_length': 65536,
+      },
+    },
+  })
+  console.log(`peek options ${JSON.stringify(client['_options'])}`)
+  await client.close()
+
+  if (!process.env['INFLUX_HOST']) {
+    process.env['INFLUX_HOST'] = 'http://localhost:8086'
+  }
+
+  if (!process.env['INFLUX_TOKEN']) {
+    process.env['INFLUX_TOKEN'] = 'my-token'
+  }
+
+  // declare grpc options using the environment variable INFLUX_GRPC_OPTIONS
+  process.env['INFLUX_GRPC_OPTIONS'] =
+    'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536'
+
+  client = new InfluxDBClient()
+  console.log(`peek options ${JSON.stringify(client['_options'])}`)
+  await client.close()
+
+  delete process.env['INFLUX_GRPC_OPTIONS']
+}
+
+main().then(() => {
+  console.log('DONE')
+})

--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -2,6 +2,8 @@ import {InfluxDBClient, Point} from '@influxdata/influxdb3-client'
 
 type Defined<T> = Exclude<T, undefined>
 
+// TODO need example of setting grpc options
+
 /* allows to throw error as expression */
 const throwReturn = <T>(err: Error): Defined<T> => {
   throw err

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -65,6 +65,7 @@ export default class InfluxDBClient {
    *   - INFLUX_PRECISION - timestamp precision when writing data
    *   - INFLUX_GZIP_THRESHOLD - payload size threshold for gzipping data
    *   - INFLUX_WRITE_NO_SYNC - skip waiting for WAL persistence on write
+   *   - INFLUX_GRPC_OPTIONS - comma separated set of key=value pairs matching @grpc/grpc-js channel options.
    */
   constructor()
 

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -93,10 +93,10 @@ export default class InfluxDBClient {
       ...DEFAULT_ConnectionOptions,
       ...options,
     }
-    // TODO improve this if possible also check for valid supported grpc values
-    // see list in @grpc/grpc-js/README.md
+
+    // see list of grpcOptions in @grpc/grpc-js/README.md
     this._options.grpcOptions = options.queryOptions?.grpcOptions
-    console.log(`DEBUG this._options ${JSON.stringify(this._options)}`)
+    // console.log(`DEBUG this._options ${JSON.stringify(this._options)}`)
     const host = this._options.host
     if (typeof host !== 'string')
       throw new IllegalArgumentError('No host specified!')

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -95,8 +95,21 @@ export default class InfluxDBClient {
     }
 
     // see list of grpcOptions in @grpc/grpc-js/README.md
-    this._options.grpcOptions = options.queryOptions?.grpcOptions
-    // console.log(`DEBUG this._options ${JSON.stringify(this._options)}`)
+    // sync grpcOptions between ConnectionOptions (needed by transport)
+    // and QueryOptions (User friendly location also more accessible via env)
+    if (this._options.grpcOptions) {
+      this._options.queryOptions = {
+         ...options.queryOptions,
+        grpcOptions: {
+          ...this._options.grpcOptions
+        }
+      }
+    } else {
+      if (options.queryOptions &&
+        options.queryOptions?.grpcOptions) {
+        this._options.grpcOptions = options.queryOptions?.grpcOptions
+      }
+    }
     const host = this._options.host
     if (typeof host !== 'string')
       throw new IllegalArgumentError('No host specified!')

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -93,6 +93,10 @@ export default class InfluxDBClient {
       ...DEFAULT_ConnectionOptions,
       ...options,
     }
+    // TODO improve this if possible also check for valid supported grpc values
+    // see list in @grpc/grpc-js/README.md
+    this._options.grpcOptions = options.queryOptions?.grpcOptions
+    console.log(`DEBUG this._options ${JSON.stringify(this._options)}`)
     const host = this._options.host
     if (typeof host !== 'string')
       throw new IllegalArgumentError('No host specified!')

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -31,11 +31,13 @@ export default class QueryApiImpl implements QueryApi {
 
     this._defaultHeaders = this._options.headers
     let clientOptions: ClientOptions = {}
-    if ( grpcOptions !== undefined ) {
+    if (grpcOptions !== undefined) {
       clientOptions = grpcOptions
     }
 
-    this._transport = impl.queryTransport({host: host, timeout: queryTimeout, clientOptions: { ...clientOptions } })
+    this._transport = impl.queryTransport(
+      {host: host, timeout: queryTimeout, clientOptions: { ...clientOptions } }
+    )
     this._flightClient = new FlightServiceClient(this._transport)
   }
 

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -10,6 +10,7 @@ import {PointFieldType, PointValues} from '../PointValues'
 import {allParamsMatched, queryHasParams} from '../util/sql'
 import {CLIENT_LIB_USER_AGENT} from './version'
 import {getMappedValue} from '../util/TypeCasting'
+import {ClientOptions} from '@grpc/grpc-js'
 
 export type TicketDataType = {
   database: string
@@ -25,10 +26,20 @@ export default class QueryApiImpl implements QueryApi {
 
   private _defaultHeaders: Record<string, string> | undefined
 
+  // TODO handle grpcClientOptions
   constructor(private _options: ConnectionOptions) {
-    const {host, queryTimeout: timeout} = this._options
+    console.log(`DEBUG ConnectionOptions ${JSON.stringify(_options)}`)
+    const {host, queryTimeout: timeout, grpcOptions, database} = this._options
+    console.log(`DEBUG database ${JSON.stringify(database)}`)
+    console.log(`DEBUG grpcOptions ${JSON.stringify(grpcOptions)}`)
     this._defaultHeaders = this._options.headers
-    this._transport = impl.queryTransport({host, timeout})
+    let clientOptions: ClientOptions = {}
+    if ( grpcOptions !== undefined ) {
+      clientOptions = grpcOptions
+    }
+    console.log(`DEBUG QueryApiImpl clientOptions ${JSON.stringify(clientOptions)}`)
+    // @ts-ignore TODO find a way to remove this ignore
+    this._transport = impl.queryTransport({host: host, timeout: timeout, clientOptions: { ...clientOptions } })
     this._flightClient = new FlightServiceClient(this._transport)
   }
 

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -35,9 +35,11 @@ export default class QueryApiImpl implements QueryApi {
       clientOptions = grpcOptions
     }
 
-    this._transport = impl.queryTransport(
-      {host: host, timeout: queryTimeout, clientOptions: { ...clientOptions } }
-    )
+    this._transport = impl.queryTransport({
+      host: host,
+      timeout: queryTimeout,
+      clientOptions: {...clientOptions},
+    })
     this._flightClient = new FlightServiceClient(this._transport)
   }
 

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -28,16 +28,17 @@ export default class QueryApiImpl implements QueryApi {
 
   // TODO handle grpcClientOptions
   constructor(private _options: ConnectionOptions) {
-    console.log(`DEBUG ConnectionOptions ${JSON.stringify(_options)}`)
-    const {host, queryTimeout: timeout, grpcOptions, database} = this._options
-    console.log(`DEBUG database ${JSON.stringify(database)}`)
-    console.log(`DEBUG grpcOptions ${JSON.stringify(grpcOptions)}`)
+    // console.log(`DEBUG ConnectionOptions ${JSON.stringify(_options)}`)
+    // const {host, queryTimeout: timeout, grpcOptions, database} = this._options
+    const {host, queryTimeout: timeout, grpcOptions} = this._options
+    // console.log(`DEBUG database ${JSON.stringify(database)}`)
+    // console.log(`DEBUG grpcOptions ${JSON.stringify(grpcOptions)}`)
     this._defaultHeaders = this._options.headers
     let clientOptions: ClientOptions = {}
     if ( grpcOptions !== undefined ) {
       clientOptions = grpcOptions
     }
-    console.log(`DEBUG QueryApiImpl clientOptions ${JSON.stringify(clientOptions)}`)
+    // console.log(`DEBUG QueryApiImpl clientOptions ${JSON.stringify(clientOptions)}`)
     // @ts-ignore TODO find a way to remove this ignore
     this._transport = impl.queryTransport({host: host, timeout: timeout, clientOptions: { ...clientOptions } })
     this._flightClient = new FlightServiceClient(this._transport)

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -26,20 +26,15 @@ export default class QueryApiImpl implements QueryApi {
 
   private _defaultHeaders: Record<string, string> | undefined
 
-  // TODO handle grpcClientOptions
   constructor(private _options: ConnectionOptions) {
-    // console.log(`DEBUG ConnectionOptions ${JSON.stringify(_options)}`)
-    // const {host, queryTimeout: timeout, grpcOptions, database} = this._options
     const {host, queryTimeout: timeout, grpcOptions} = this._options
-    // console.log(`DEBUG database ${JSON.stringify(database)}`)
-    // console.log(`DEBUG grpcOptions ${JSON.stringify(grpcOptions)}`)
+
     this._defaultHeaders = this._options.headers
     let clientOptions: ClientOptions = {}
     if ( grpcOptions !== undefined ) {
       clientOptions = grpcOptions
     }
-    // console.log(`DEBUG QueryApiImpl clientOptions ${JSON.stringify(clientOptions)}`)
-    // @ts-ignore TODO find a way to remove this ignore
+
     this._transport = impl.queryTransport({host: host, timeout: timeout, clientOptions: { ...clientOptions } })
     this._flightClient = new FlightServiceClient(this._transport)
   }

--- a/packages/client/src/impl/QueryApiImpl.ts
+++ b/packages/client/src/impl/QueryApiImpl.ts
@@ -27,7 +27,7 @@ export default class QueryApiImpl implements QueryApi {
   private _defaultHeaders: Record<string, string> | undefined
 
   constructor(private _options: ConnectionOptions) {
-    const {host, queryTimeout: timeout, grpcOptions} = this._options
+    const {host, queryTimeout, grpcOptions} = this._options
 
     this._defaultHeaders = this._options.headers
     let clientOptions: ClientOptions = {}
@@ -35,7 +35,7 @@ export default class QueryApiImpl implements QueryApi {
       clientOptions = grpcOptions
     }
 
-    this._transport = impl.queryTransport({host: host, timeout: timeout, clientOptions: { ...clientOptions } })
+    this._transport = impl.queryTransport({host: host, timeout: queryTimeout, clientOptions: { ...clientOptions } })
     this._flightClient = new FlightServiceClient(this._transport)
   }
 

--- a/packages/client/src/impl/browser/rpc.ts
+++ b/packages/client/src/impl/browser/rpc.ts
@@ -4,7 +4,6 @@ import {CreateQueryTransport} from '../implSelector'
 export const createTransport: CreateQueryTransport = ({host, timeout, clientOptions}) => {
 
   if (clientOptions) {
-    // TODO use logger
     console.warn(`Detected grpcClientOptions: such options are ignored in the GrpcWebFetchTransport:\n
     ${JSON.stringify(clientOptions)}`)
   }

--- a/packages/client/src/impl/browser/rpc.ts
+++ b/packages/client/src/impl/browser/rpc.ts
@@ -1,9 +1,11 @@
 import {GrpcWebFetchTransport} from '@protobuf-ts/grpcweb-transport'
 import {CreateQueryTransport} from '../implSelector'
 
-export const createTransport: CreateQueryTransport = (
-  {host, timeout, clientOptions}
-) => {
+export const createTransport: CreateQueryTransport = ({
+  host,
+  timeout,
+  clientOptions
+}) => {
 
   if (clientOptions) {
     console.warn(`Detected grpcClientOptions: such options are ignored in the GrpcWebFetchTransport:\n

--- a/packages/client/src/impl/browser/rpc.ts
+++ b/packages/client/src/impl/browser/rpc.ts
@@ -1,7 +1,9 @@
 import {GrpcWebFetchTransport} from '@protobuf-ts/grpcweb-transport'
 import {CreateQueryTransport} from '../implSelector'
 
-export const createTransport: CreateQueryTransport = ({host, timeout, clientOptions}) => {
+export const createTransport: CreateQueryTransport = (
+  {host, timeout, clientOptions}
+) => {
 
   if (clientOptions) {
     console.warn(`Detected grpcClientOptions: such options are ignored in the GrpcWebFetchTransport:\n

--- a/packages/client/src/impl/browser/rpc.ts
+++ b/packages/client/src/impl/browser/rpc.ts
@@ -4,9 +4,8 @@ import {CreateQueryTransport} from '../implSelector'
 export const createTransport: CreateQueryTransport = ({
   host,
   timeout,
-  clientOptions
+  clientOptions,
 }) => {
-
   if (clientOptions) {
     console.warn(`Detected grpcClientOptions: such options are ignored in the GrpcWebFetchTransport:\n
     ${JSON.stringify(clientOptions)}`)

--- a/packages/client/src/impl/browser/rpc.ts
+++ b/packages/client/src/impl/browser/rpc.ts
@@ -1,12 +1,12 @@
 import {GrpcWebFetchTransport} from '@protobuf-ts/grpcweb-transport'
 import {CreateQueryTransport} from '../implSelector'
 
-export const createTransport: CreateQueryTransport = ({host, timeout, grpcClientOptions}) => {
+export const createTransport: CreateQueryTransport = ({host, timeout, clientOptions}) => {
 
-  if (grpcClientOptions) {
+  if (clientOptions) {
     // TODO use logger
     console.warn(`Detected grpcClientOptions: such options are ignored in the GrpcWebFetchTransport:\n
-    ${JSON.stringify(grpcClientOptions)}`)
+    ${JSON.stringify(clientOptions)}`)
   }
   return new GrpcWebFetchTransport({baseUrl: host, timeout})
 }

--- a/packages/client/src/impl/browser/rpc.ts
+++ b/packages/client/src/impl/browser/rpc.ts
@@ -1,6 +1,12 @@
 import {GrpcWebFetchTransport} from '@protobuf-ts/grpcweb-transport'
 import {CreateQueryTransport} from '../implSelector'
 
-export const createTransport: CreateQueryTransport = ({host, timeout}) => {
+export const createTransport: CreateQueryTransport = ({host, timeout, grpcClientOptions}) => {
+
+  if (grpcClientOptions) {
+    // TODO use logger
+    console.warn(`Detected grpcClientOptions: such options are ignored in the GrpcWebFetchTransport:\n
+    ${JSON.stringify(grpcClientOptions)}`)
+  }
   return new GrpcWebFetchTransport({baseUrl: host, timeout})
 }

--- a/packages/client/src/impl/implSelector.ts
+++ b/packages/client/src/impl/implSelector.ts
@@ -4,6 +4,7 @@
 import {RpcTransport} from '@protobuf-ts/runtime-rpc'
 import {Transport} from '../transport'
 import {ClientOptions} from '../options'
+// import * as grpc from '@grpc/grpc-js/'
 
 // This import path is replaced by tsup for browser. Don't change path for ./node or ./browser!
 export {default as impl} from './node'
@@ -16,6 +17,7 @@ export type CreateWriteTransport = (options: ClientOptions) => Transport
 export type CreateQueryTransport = (options: {
   host: string
   timeout?: number
+  clientOptions?: Record<string, any>
 }) => RpcTransport & MaybeCloseable
 
 export type TargetBasedImplementation = {

--- a/packages/client/src/impl/node/rpc.ts
+++ b/packages/client/src/impl/node/rpc.ts
@@ -10,7 +10,7 @@ export const createTransport: CreateQueryTransport = ({
 }) => {
   const {url, safe} = replaceURLProtocolWithPort(host)
   const channelCredentials =
-    grpc.credentials[(safe ?? true) ? 'createSsl' : 'createInsecure']()
+    grpc.credentials[ safe ?? true ? 'createSsl' : 'createInsecure']()
 
   return new GrpcTransport({
     host: url,

--- a/packages/client/src/impl/node/rpc.ts
+++ b/packages/client/src/impl/node/rpc.ts
@@ -8,7 +8,7 @@ export const createTransport: CreateQueryTransport = ({host, timeout, clientOpti
   const channelCredentials =
     grpc.credentials[safe ?? true ? 'createSsl' : 'createInsecure']()
 
-  console.log(`DEBUG createTransport grpcClientOptions ${JSON.stringify(clientOptions)}`)
+  // console.log(`DEBUG createTransport grpcClientOptions ${JSON.stringify(clientOptions)}`)
 
   // TODO is timeout used?
   return new GrpcTransport(

--- a/packages/client/src/impl/node/rpc.ts
+++ b/packages/client/src/impl/node/rpc.ts
@@ -10,7 +10,7 @@ export const createTransport: CreateQueryTransport = ({
 }) => {
   const {url, safe} = replaceURLProtocolWithPort(host)
   const channelCredentials =
-    grpc.credentials[ safe ?? true ? 'createSsl' : 'createInsecure']()
+    grpc.credentials[safe ?? true ? 'createSsl' : 'createInsecure']()
 
   return new GrpcTransport({
     host: url,

--- a/packages/client/src/impl/node/rpc.ts
+++ b/packages/client/src/impl/node/rpc.ts
@@ -3,10 +3,15 @@ import {replaceURLProtocolWithPort} from '../../util/fixUrl'
 import {CreateQueryTransport} from '../implSelector'
 import * as grpc from '@grpc/grpc-js'
 
-export const createTransport: CreateQueryTransport = ({host, timeout}) => {
+export const createTransport: CreateQueryTransport = ({host, timeout, clientOptions }) => {
   const {url, safe} = replaceURLProtocolWithPort(host)
   const channelCredentials =
     grpc.credentials[safe ?? true ? 'createSsl' : 'createInsecure']()
 
-  return new GrpcTransport({host: url, channelCredentials, timeout})
+  console.log(`DEBUG createTransport grpcClientOptions ${JSON.stringify(clientOptions)}`)
+
+  // TODO is timeout used?
+  return new GrpcTransport(
+     {host: url, channelCredentials: channelCredentials, clientOptions: clientOptions, timeout}
+  )
 }

--- a/packages/client/src/impl/node/rpc.ts
+++ b/packages/client/src/impl/node/rpc.ts
@@ -3,12 +3,19 @@ import {replaceURLProtocolWithPort} from '../../util/fixUrl'
 import {CreateQueryTransport} from '../implSelector'
 import * as grpc from '@grpc/grpc-js'
 
-export const createTransport: CreateQueryTransport = ({host, timeout, clientOptions }) => {
+export const createTransport: CreateQueryTransport = ({
+  host,
+  timeout,
+  clientOptions,
+}) => {
   const {url, safe} = replaceURLProtocolWithPort(host)
   const channelCredentials =
-    grpc.credentials[safe ?? true ? 'createSsl' : 'createInsecure']()
+    grpc.credentials[(safe ?? true) ? 'createSsl' : 'createInsecure']()
 
-  return new GrpcTransport(
-     {host: url, channelCredentials: channelCredentials, clientOptions: clientOptions, timeout: timeout}
-  )
+  return new GrpcTransport({
+    host: url,
+    channelCredentials: channelCredentials,
+    clientOptions: clientOptions,
+    timeout: timeout,
+  })
 }

--- a/packages/client/src/impl/node/rpc.ts
+++ b/packages/client/src/impl/node/rpc.ts
@@ -8,8 +8,7 @@ export const createTransport: CreateQueryTransport = ({host, timeout, clientOpti
   const channelCredentials =
     grpc.credentials[safe ?? true ? 'createSsl' : 'createInsecure']()
 
-  // TODO is timeout used?
   return new GrpcTransport(
-     {host: url, channelCredentials: channelCredentials, clientOptions: clientOptions, timeout}
+     {host: url, channelCredentials: channelCredentials, clientOptions: clientOptions, timeout: timeout}
   )
 }

--- a/packages/client/src/impl/node/rpc.ts
+++ b/packages/client/src/impl/node/rpc.ts
@@ -8,8 +8,6 @@ export const createTransport: CreateQueryTransport = ({host, timeout, clientOpti
   const channelCredentials =
     grpc.credentials[safe ?? true ? 'createSsl' : 'createInsecure']()
 
-  // console.log(`DEBUG createTransport grpcClientOptions ${JSON.stringify(clientOptions)}`)
-
   // TODO is timeout used?
   return new GrpcTransport(
      {host: url, channelCredentials: channelCredentials, clientOptions: clientOptions, timeout}

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -167,8 +167,7 @@ export interface QueryOptions {
   headers?: Record<string, string>
   /** Parameters to accompany a query using them.*/
   params?: Record<string, QParamType>
-  /** GRPC specific Parameters to be set when instantiating client **/
-  /** Note these are ignored when used directly in a call **/
+  /** GRPC specific Parameters to be set when instantiating a client **/
   grpcOptions?: Record<string, any>
 }
 

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -285,6 +285,25 @@ export function fromEnv(): ClientOptions {
     if (!options.writeOptions) options.writeOptions = {} as WriteOptions
     options.writeOptions.noSync = parseBoolean(process.env.INFLUX_WRITE_NO_SYNC)
   }
+  if (process.env.INFLUX_GRPC_OPTIONS) {
+    const optionSets = process.env.INFLUX_GRPC_OPTIONS.split(',')
+    if(!options.grpcOptions) options.grpcOptions = {} as Record<string,any>
+    for(const optSet of optionSets){
+      const kvPair = optSet.split("=")
+      // ignore malformed values
+      if(kvPair.length != 2){
+        continue
+      }
+      let value: any = parseFloat(kvPair[1])
+      if(Number.isNaN(value)) {
+        value = parseInt(kvPair[1])
+        if(Number.isNaN(value)) {
+          value = kvPair[1]
+        }
+      }
+      options.grpcOptions[kvPair[0]] = value;
+    }
+  }
 
   return options
 }

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -294,9 +294,9 @@ export function fromEnv(): ClientOptions {
       if(kvPair.length != 2){
         continue
       }
-      let value: any = parseFloat(kvPair[1])
+      let value: any = parseInt(kvPair[1])
       if(Number.isNaN(value)) {
-        value = parseInt(kvPair[1])
+        value = parseFloat(kvPair[1])
         if(Number.isNaN(value)) {
           value = kvPair[1]
         }

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -46,6 +46,11 @@ export interface ConnectionOptions {
    * Full HTTP web proxy URL including schema, for example http://your-proxy:8080.
    */
   proxyUrl?: string
+
+  /**
+   * Grpc options to be passed when instantiation query transport
+   */
+  grpcOptions?: Record<string, any>
 }
 
 /** default connection options */
@@ -162,6 +167,9 @@ export interface QueryOptions {
   headers?: Record<string, string>
   /** Parameters to accompany a query using them.*/
   params?: Record<string, QParamType>
+  /** GRPC specific Parameters to be set when instantiating client **/
+  /** Note these are ignored when used directly in a call **/
+  grpcOptions?: Record<string, any>
 }
 
 /** Default QueryOptions */

--- a/packages/client/test/TestServer.ts
+++ b/packages/client/test/TestServer.ts
@@ -190,9 +190,12 @@ export class MockService {
     this.callTickets.set(callId, ticket)
   }
 
-  public static handleBlob(call: grpc.ServerWritableStream<flt.Ticket, flt.FlightData>, size: number) {
-    let data = new Uint8Array(size);
-    for(let i = 0; i < data.length; i++){
+  public static handleBlob(
+    call: grpc.ServerWritableStream<flt.Ticket, flt.FlightData>,
+    size: number
+  ): void {
+    const data = new Uint8Array(size)
+    for (let i = 0; i < data.length; i++) {
       data[i] = Math.floor(Math.random() * 96) + 32
     }
     const decoder = new TextDecoder('utf-8')
@@ -233,12 +236,15 @@ export class MockService {
         Log.error.call(Log, `MockService ERROR on doGet() ${args}`)
       })
 
-      let metadata = call.metadata;
-      let path = call.getPath()
+      const metadata = call.metadata
+      const path = call.getPath()
 
-      if (metadata.get("sendblob").length > 0) {
-        let blobSize = Number.parseInt(metadata.get("sendblob").toString())
-        blobSize = Number.isNaN(blobSize) || blobSize < 1 ? MockService.defaultBlobSize : blobSize
+      if (metadata.get('sendblob').length > 0) {
+        let blobSize = Number.parseInt(metadata.get('sendblob').toString())
+        blobSize =
+          Number.isNaN(blobSize) || blobSize < 1
+            ? MockService.defaultBlobSize
+            : blobSize
         MockService.handleBlob(call, blobSize)
       } else {
         // echo metadata back
@@ -250,8 +256,8 @@ export class MockService {
         MockService.sendEmptyResponseBody(call, path)
       }
 
-      if (metadata.get("delay").length > 0){
-        timeout = Number.parseInt(metadata.get("delay").toString())
+      if (metadata.get('delay').length > 0) {
+        timeout = Number.parseInt(metadata.get('delay').toString())
       }
       setTimeout(() => {
         call.end(metadata)

--- a/packages/client/test/TestServer.ts
+++ b/packages/client/test/TestServer.ts
@@ -219,6 +219,7 @@ export class MockService {
       )
     },
     doGet(call: grpc.ServerWritableStream<flt.Ticket, flt.FlightData>): void {
+      let timeout = 0
       MockService.callCount.doGet++
       MockService.pushCallMetadata(
         MockService.genCallId('doGet', MockService.callCount.doGet),
@@ -248,8 +249,13 @@ export class MockService {
         // Send ResponseBody
         MockService.sendEmptyResponseBody(call, path)
       }
-      call.end(metadata)
 
+      if (metadata.get("delay").length > 0){
+        timeout = Number.parseInt(metadata.get("delay").toString())
+      }
+      setTimeout(() => {
+        call.end(metadata)
+      }, timeout)
     },
     doPut(call: grpc.ServerDuplexStream<flt.FlightData, flt.PutResult>): void {
       MockService.callCount.doPut++

--- a/packages/client/test/integration/queryAPI.test.ts
+++ b/packages/client/test/integration/queryAPI.test.ts
@@ -1,16 +1,14 @@
 import {expect, assert} from 'chai'
 import {InfluxDBClient, QueryOptions, DEFAULT_QueryOptions} from '../../src'
 import {MockService, TestServer} from '../TestServer'
-;
-import {expectResolve, expectThrowsAsync} from "../util";
+import {expectResolve, expectThrowsAsync} from '../util'
 //import { RpcError } from "@protobuf-ts/runtime-rpc";
-
-(BigInt.prototype as any).toJSON = function () {
+;(BigInt.prototype as any).toJSON = function () {
   return this.toString()
 }
 
 const grpcVersion: string =
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   require('../../../../node_modules/@grpc/grpc-js/package.json').version
 
 const USER_AGENT = `grpc-node-js/${grpcVersion}`
@@ -247,7 +245,7 @@ describe('query api tests', () => {
   })
   it('grpc - fails on large received message', async () => {
     // const blobSize = (1024 * 1024 * 4) + 1000
-    const blobSize = (1024 * 1024 * 4) + 1000
+    const blobSize = 1024 * 1024 * 4 + 1000
     const client: InfluxDBClient = new InfluxDBClient({
       host: `http://localhost:${server.port}`,
       token: 'TEST_TOKEN',
@@ -267,13 +265,17 @@ describe('query api tests', () => {
       },
     })
 
-    await expectThrowsAsync(async () => {
-      const data = client.query("SELECT * FROM wumpus", "CI_TEST")
-      await data.next()
-    }, 'Received message larger than max (4195310 vs 4194304)', 'RpcError')
+    await expectThrowsAsync(
+      async () => {
+        const data = client.query('SELECT * FROM wumpus', 'CI_TEST')
+        await data.next()
+      },
+      'Received message larger than max (4195310 vs 4194304)',
+      'RpcError'
+    )
   })
   it('grpc - sets large receive message size', async () => {
-    const blobSize = (1024 * 1024 * 4) + 1000
+    const blobSize = 1024 * 1024 * 4 + 1000
     const client: InfluxDBClient = new InfluxDBClient({
       host: `http://localhost:${server.port}`,
       token: 'TEST_TOKEN',
@@ -291,17 +293,17 @@ describe('query api tests', () => {
           acteur: 'R_NAVARRE',
         },
         grpcOptions: {
-          "grpc.max_receive_message_length": blobSize + 100
-        }
+          'grpc.max_receive_message_length': blobSize + 100,
+        },
       },
     })
 
     await expectResolve(async () => {
-      const data = client.query("SELECT * FROM wumpus", "CI_TEST")
+      const data = client.query('SELECT * FROM wumpus', 'CI_TEST')
       await data.next()
     })
   })
-  it('grpc - fails on a restricted send message size', async() => {
+  it('grpc - fails on a restricted send message size', async () => {
     const blobSize = 65536
     const client: InfluxDBClient = new InfluxDBClient({
       host: `http://localhost:${server.port}`,
@@ -320,18 +322,21 @@ describe('query api tests', () => {
           acteur: 'R_NAVARRE',
         },
         grpcOptions: {
-          "grpc.max_send_message_length": 16
-        }
+          'grpc.max_send_message_length': 16,
+        },
       },
     })
 
-     await expectThrowsAsync(async () => {
-        const data = client.query("SELECT * FROM wumpus", "CI_TEST")
+    await expectThrowsAsync(
+      async () => {
+        const data = client.query('SELECT * FROM wumpus', 'CI_TEST')
         await data.next()
-     }, 'Attempted to send message with a size larger than 16', 'RpcError'
+      },
+      'Attempted to send message with a size larger than 16',
+      'RpcError'
     )
   })
-  it('times out', async function(){
+  it('times out', async function () {
     this.timeout(3000)
     const client: InfluxDBClient = new InfluxDBClient({
       host: `http://localhost:${server.port}`,
@@ -351,15 +356,18 @@ describe('query api tests', () => {
           acteur: 'R_NAVARRE',
         },
         grpcOptions: {
-          "grpc.max_send_message_length": 256
-        }
+          'grpc.max_send_message_length': 256,
+        },
       },
     })
 
-    await expectThrowsAsync(async () => {
-      const data = client.query("SELECT * FROM wumpus", "CI_TEST")
-      await data.next()
-    }, /^Deadline exceeded.*/, "RpcError")
-
+    await expectThrowsAsync(
+      async () => {
+        const data = client.query('SELECT * FROM wumpus', 'CI_TEST')
+        await data.next()
+      },
+      /^Deadline exceeded.*/,
+      'RpcError'
+    )
   })
 })

--- a/packages/client/test/integration/queryAPI.test.ts
+++ b/packages/client/test/integration/queryAPI.test.ts
@@ -326,9 +326,40 @@ describe('query api tests', () => {
     })
 
      await expectThrowsAsync(async () => {
-        const data = client.query("SELECT * FROM wumpus", "CI_TST")
+        const data = client.query("SELECT * FROM wumpus", "CI_TEST")
         await data.next()
      }, 'Attempted to send message with a size larger than 16', 'RpcError'
     )
+  })
+  it('times out', async function(){
+    this.timeout(3000)
+    const client: InfluxDBClient = new InfluxDBClient({
+      host: `http://localhost:${server.port}`,
+      token: 'TEST_TOKEN',
+      database: 'CI_TEST',
+      queryTimeout: 100,
+      headers: {
+        extra: 'yes',
+        delay: '2000',
+      },
+      queryOptions: {
+        headers: {
+          special: 'super',
+        },
+        params: {
+          ecrivain: 'E_ZOLA',
+          acteur: 'R_NAVARRE',
+        },
+        grpcOptions: {
+          "grpc.max_send_message_length": 256
+        }
+      },
+    })
+
+    await expectThrowsAsync(async () => {
+      const data = client.query("SELECT * FROM wumpus", "CI_TEST")
+      await data.next()
+    }, /^Deadline exceeded.*/, "RpcError")
+
   })
 })

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -709,6 +709,32 @@ at 'ClientOptions.database'
       const client: any = new InfluxDBClient()
       expect(client._options).to.deep.equal(expectedOptions)
     })
+    it('grpc - handles non-standard grpc value', async() => {
+      clear()
+      process.env['INFLUX_HOST'] = 'https://localhost:8086'
+      process.env['INFLUX_TOKEN'] = 'my-token'
+      process.env['INFLUX_GRPC_OPTIONS'] =
+        'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536,grpc.foo=bar';
+      const expectedOptions = {
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        grpcOptions: {
+          "grpc.max_receive_message_length": 65536,
+          "grpc.max_send_message_length": 65536,
+          "grpc.foo": "bar",
+        },
+        queryOptions: {
+          grpcOptions: {
+            'grpc.max_receive_message_length': 65536,
+            'grpc.max_send_message_length': 65536,
+            'grpc.foo': 'bar',
+          }
+        }
+      }
+      const client: any = new InfluxDBClient()
+      expect(client._options).to.deep.equal(expectedOptions)
+    })
   })
   describe('options handling', () => {
     const DATABASE = 'TEST_DATABASE'

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -13,7 +13,7 @@ import type QueryApi from '../../src/QueryApi'
 import {rejects} from 'assert'
 import nock from 'nock'
 
-const TEST_ConnectionOptions = {
+const LOCAL_DEFAULT_ConnectionOptions = {
   ...DEFAULT_ConnectionOptions,
   grpcOptions: undefined
 }
@@ -101,7 +101,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -115,7 +115,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -211,7 +211,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -231,7 +231,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -257,7 +257,7 @@ at 'ClientOptions.database'
         (new InfluxDBClient('https://localhost:8086?token=my-token') as any)
           ._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -270,7 +270,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         authScheme: 'my-scheme',
@@ -281,7 +281,7 @@ at 'ClientOptions.database'
         (new InfluxDBClient(' https://localhost:8086?token=my-token ') as any)
           ._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -294,7 +294,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         database: 'my-database',
@@ -308,7 +308,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         timeout: 75,
@@ -322,7 +322,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -338,7 +338,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -354,7 +354,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -370,7 +370,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -386,7 +386,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -402,7 +402,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -418,7 +418,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -459,7 +459,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = 'https://localhost:8086'
       process.env['INFLUX_TOKEN'] = 'my-token'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -470,7 +470,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_AUTH_SCHEME'] = 'my-scheme'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         authScheme: 'my-scheme',
@@ -481,7 +481,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = ' https://localhost:8086 '
       process.env['INFLUX_TOKEN'] = ' my-token '
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -492,7 +492,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_DATABASE'] = 'my-database'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         database: 'my-database',
@@ -504,7 +504,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_TIMEOUT'] = '75'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         timeout: 75,
@@ -516,7 +516,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_PRECISION'] = 'us'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -530,7 +530,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_PRECISION'] = 'nanosecond'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -544,7 +544,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_GZIP_THRESHOLD'] = '128'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -558,7 +558,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'true'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -572,7 +572,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'false'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -586,7 +586,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'invalid'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -602,7 +602,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_GZIP_THRESHOLD'] = '128'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'true'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...TEST_ConnectionOptions,
+        ...LOCAL_DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -13,11 +13,6 @@ import type QueryApi from '../../src/QueryApi'
 import {rejects} from 'assert'
 import nock from 'nock'
 
-const CONNECTION_TEST_OPTIONS = {
-  ...DEFAULT_ConnectionOptions,
-  grpcOptions: undefined,
-}
-
 describe('InfluxDB', () => {
   afterEach(() => {
     sinon.restore()
@@ -101,7 +96,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -115,7 +110,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -211,7 +206,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -231,13 +226,67 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
           noSync: false,
         },
       })
+    })
+    it('creates instance with grpc options', () => {
+      const expectedOptions = {
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        grpcOptions: {
+          "grpc.max_receive_message_length": 65536,
+          "grpc.max_send_message_length": 65536,
+        },
+        queryOptions: {
+          grpcOptions: {
+            'grpc.max_receive_message_length': 65536,
+            'grpc.max_send_message_length': 65536,
+          }
+        }
+      }
+      const clients = {
+        client1 : new InfluxDBClient({
+          host: 'https://localhost:8086',
+          token: 'my-token',
+          queryOptions: {
+            grpcOptions: {
+              'grpc.max_receive_message_length': 65536,
+              'grpc.max_send_message_length': 65536,
+            }
+          }
+        }),
+        client2 : new InfluxDBClient({
+          host: 'https://localhost:8086',
+          token: 'my-token',
+          grpcOptions: {
+              'grpc.max_receive_message_length': 65536,
+              'grpc.max_send_message_length': 65536,
+          }
+        }),
+        client3 : new InfluxDBClient({
+          host: 'https://localhost:8086',
+          token: 'my-token',
+          grpcOptions: {
+            'grpc.max_receive_message_length': 65536,
+            'grpc.max_send_message_length': 65536,
+          },
+          queryOptions: {
+            grpcOptions: {
+              'grpc.max_receive_message_length': 32768,
+              'grpc.max_send_message_length': 32768,
+            }
+          }
+        })
+      }
+      for (const client of Object.values(clients)){
+        expect((client as any)._options).to.deep.equal(expectedOptions)
+      }
     })
   })
 
@@ -257,7 +306,7 @@ at 'ClientOptions.database'
         (new InfluxDBClient('https://localhost:8086?token=my-token') as any)
           ._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -270,7 +319,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         authScheme: 'my-scheme',
@@ -281,7 +330,7 @@ at 'ClientOptions.database'
         (new InfluxDBClient(' https://localhost:8086?token=my-token ') as any)
           ._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -294,7 +343,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         database: 'my-database',
@@ -308,7 +357,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         timeout: 75,
@@ -322,7 +371,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -338,7 +387,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -354,7 +403,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -370,7 +419,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -386,7 +435,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -402,7 +451,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -418,7 +467,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -440,6 +489,7 @@ at 'ClientOptions.database'
       delete process.env['INFLUX_PRECISION']
       delete process.env['INFLUX_GZIP_THRESHOLD']
       delete process.env['INFLUX_WRITE_NO_SYNC']
+      delete process.env['INFLUX_GRPC_OPTIONS']
     }
     it('fails on missing host', () => {
       clear()
@@ -459,7 +509,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = 'https://localhost:8086'
       process.env['INFLUX_TOKEN'] = 'my-token'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -470,7 +520,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_AUTH_SCHEME'] = 'my-scheme'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         authScheme: 'my-scheme',
@@ -481,7 +531,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = ' https://localhost:8086 '
       process.env['INFLUX_TOKEN'] = ' my-token '
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -492,7 +542,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_DATABASE'] = 'my-database'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         database: 'my-database',
@@ -504,7 +554,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_TIMEOUT'] = '75'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         timeout: 75,
@@ -516,7 +566,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_PRECISION'] = 'us'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -530,7 +580,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_PRECISION'] = 'nanosecond'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -544,7 +594,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_GZIP_THRESHOLD'] = '128'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -558,7 +608,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'true'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -572,7 +622,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'false'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -586,7 +636,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'invalid'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -602,7 +652,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_GZIP_THRESHOLD'] = '128'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'true'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...CONNECTION_TEST_OPTIONS,
+        ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -611,6 +661,53 @@ at 'ClientOptions.database'
           noSync: true,
         } as WriteOptions,
       })
+    })
+    it('grpc - creates a host with grpc options', () => {
+      clear()
+      process.env['INFLUX_HOST'] = 'https://localhost:8086'
+      process.env['INFLUX_TOKEN'] = 'my-token'
+      process.env['INFLUX_GRPC_OPTIONS'] = 'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536';
+      const expectedOptions = {
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        grpcOptions: {
+          "grpc.max_receive_message_length": 65536,
+          "grpc.max_send_message_length": 65536,
+        },
+        queryOptions: {
+          grpcOptions: {
+            'grpc.max_receive_message_length': 65536,
+            'grpc.max_send_message_length': 65536,
+          }
+        }
+      }
+      const client: any = new InfluxDBClient()
+      expect(client._options).to.deep.equal(expectedOptions)
+    })
+    it('grpc - handles illegal values in grpc environment variables', () => {
+      clear()
+      process.env['INFLUX_HOST'] = 'https://localhost:8086'
+      process.env['INFLUX_TOKEN'] = 'my-token'
+      process.env['INFLUX_GRPC_OPTIONS'] =
+        'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536,grpc.garbled';
+      const expectedOptions = {
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        grpcOptions: {
+          "grpc.max_receive_message_length": 65536,
+          "grpc.max_send_message_length": 65536,
+        },
+        queryOptions: {
+          grpcOptions: {
+            'grpc.max_receive_message_length': 65536,
+            'grpc.max_send_message_length': 65536,
+          }
+        }
+      }
+      const client: any = new InfluxDBClient()
+      expect(client._options).to.deep.equal(expectedOptions)
     })
   })
   describe('options handling', () => {

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -13,6 +13,11 @@ import type QueryApi from '../../src/QueryApi'
 import {rejects} from 'assert'
 import nock from 'nock'
 
+const TEST_ConnectionOptions = {
+  ...DEFAULT_ConnectionOptions,
+  grpcOptions: undefined
+}
+
 describe('InfluxDB', () => {
   afterEach(() => {
     sinon.restore()
@@ -96,7 +101,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -110,7 +115,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -206,7 +211,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -226,7 +231,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -252,7 +257,7 @@ at 'ClientOptions.database'
         (new InfluxDBClient('https://localhost:8086?token=my-token') as any)
           ._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -265,7 +270,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         authScheme: 'my-scheme',
@@ -276,7 +281,7 @@ at 'ClientOptions.database'
         (new InfluxDBClient(' https://localhost:8086?token=my-token ') as any)
           ._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -289,7 +294,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         database: 'my-database',
@@ -303,7 +308,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         timeout: 75,
@@ -317,7 +322,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -333,7 +338,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -349,7 +354,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -365,7 +370,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -381,7 +386,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -397,7 +402,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -413,7 +418,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -454,7 +459,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = 'https://localhost:8086'
       process.env['INFLUX_TOKEN'] = 'my-token'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -465,7 +470,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_AUTH_SCHEME'] = 'my-scheme'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         authScheme: 'my-scheme',
@@ -476,7 +481,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = ' https://localhost:8086 '
       process.env['INFLUX_TOKEN'] = ' my-token '
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -487,7 +492,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_DATABASE'] = 'my-database'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         database: 'my-database',
@@ -499,7 +504,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_TIMEOUT'] = '75'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         timeout: 75,
@@ -511,7 +516,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_PRECISION'] = 'us'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -525,7 +530,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_PRECISION'] = 'nanosecond'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -539,7 +544,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_GZIP_THRESHOLD'] = '128'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -553,7 +558,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'true'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -567,7 +572,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'false'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -581,7 +586,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'invalid'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -597,7 +602,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_GZIP_THRESHOLD'] = '128'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'true'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...DEFAULT_ConnectionOptions,
+        ...TEST_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -240,36 +240,36 @@ at 'ClientOptions.database'
         host: 'https://localhost:8086',
         token: 'my-token',
         grpcOptions: {
-          "grpc.max_receive_message_length": 65536,
-          "grpc.max_send_message_length": 65536,
+          'grpc.max_receive_message_length': 65536,
+          'grpc.max_send_message_length': 65536,
         },
         queryOptions: {
           grpcOptions: {
             'grpc.max_receive_message_length': 65536,
             'grpc.max_send_message_length': 65536,
-          }
-        }
+          },
+        },
       }
       const clients = {
-        client1 : new InfluxDBClient({
+        client1: new InfluxDBClient({
           host: 'https://localhost:8086',
           token: 'my-token',
           queryOptions: {
             grpcOptions: {
               'grpc.max_receive_message_length': 65536,
               'grpc.max_send_message_length': 65536,
-            }
-          }
+            },
+          },
         }),
-        client2 : new InfluxDBClient({
+        client2: new InfluxDBClient({
           host: 'https://localhost:8086',
           token: 'my-token',
           grpcOptions: {
-              'grpc.max_receive_message_length': 65536,
-              'grpc.max_send_message_length': 65536,
-          }
+            'grpc.max_receive_message_length': 65536,
+            'grpc.max_send_message_length': 65536,
+          },
         }),
-        client3 : new InfluxDBClient({
+        client3: new InfluxDBClient({
           host: 'https://localhost:8086',
           token: 'my-token',
           grpcOptions: {
@@ -280,11 +280,11 @@ at 'ClientOptions.database'
             grpcOptions: {
               'grpc.max_receive_message_length': 32768,
               'grpc.max_send_message_length': 32768,
-            }
-          }
-        })
+            },
+          },
+        }),
       }
-      for (const client of Object.values(clients)){
+      for (const client of Object.values(clients)) {
         expect((client as any)._options).to.deep.equal(expectedOptions)
       }
     })
@@ -666,21 +666,22 @@ at 'ClientOptions.database'
       clear()
       process.env['INFLUX_HOST'] = 'https://localhost:8086'
       process.env['INFLUX_TOKEN'] = 'my-token'
-      process.env['INFLUX_GRPC_OPTIONS'] = 'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536';
+      process.env['INFLUX_GRPC_OPTIONS'] =
+        'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536';
       const expectedOptions = {
         ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         grpcOptions: {
-          "grpc.max_receive_message_length": 65536,
-          "grpc.max_send_message_length": 65536,
+          'grpc.max_receive_message_length': 65536,
+          'grpc.max_send_message_length': 65536,
         },
         queryOptions: {
           grpcOptions: {
             'grpc.max_receive_message_length': 65536,
             'grpc.max_send_message_length': 65536,
-          }
-        }
+          },
+        },
       }
       const client: any = new InfluxDBClient()
       expect(client._options).to.deep.equal(expectedOptions)
@@ -690,47 +691,47 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = 'https://localhost:8086'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_GRPC_OPTIONS'] =
-        'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536,grpc.garbled';
+        'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536,grpc.garbled'
       const expectedOptions = {
         ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         grpcOptions: {
-          "grpc.max_receive_message_length": 65536,
-          "grpc.max_send_message_length": 65536,
+          'grpc.max_receive_message_length': 65536,
+          'grpc.max_send_message_length': 65536,
         },
         queryOptions: {
           grpcOptions: {
             'grpc.max_receive_message_length': 65536,
             'grpc.max_send_message_length': 65536,
-          }
-        }
+          },
+        },
       }
       const client: any = new InfluxDBClient()
       expect(client._options).to.deep.equal(expectedOptions)
     })
-    it('grpc - handles non-standard grpc value', async() => {
+    it('grpc - handles non-standard grpc value', async () => {
       clear()
       process.env['INFLUX_HOST'] = 'https://localhost:8086'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_GRPC_OPTIONS'] =
-        'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536,grpc.foo=bar';
+        'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536,grpc.foo=bar'
       const expectedOptions = {
         ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
         token: 'my-token',
         grpcOptions: {
-          "grpc.max_receive_message_length": 65536,
-          "grpc.max_send_message_length": 65536,
-          "grpc.foo": "bar",
+          'grpc.max_receive_message_length': 65536,
+          'grpc.max_send_message_length': 65536,
+          'grpc.foo': 'bar',
         },
         queryOptions: {
           grpcOptions: {
             'grpc.max_receive_message_length': 65536,
             'grpc.max_send_message_length': 65536,
             'grpc.foo': 'bar',
-          }
-        }
+          },
+        },
       }
       const client: any = new InfluxDBClient()
       expect(client._options).to.deep.equal(expectedOptions)

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -13,7 +13,7 @@ import type QueryApi from '../../src/QueryApi'
 import {rejects} from 'assert'
 import nock from 'nock'
 
-const LOCAL_DEFAULT_ConnectionOptions = {
+const CONNECTION_TEST_OPTIONS = {
   ...DEFAULT_ConnectionOptions,
   grpcOptions: undefined
 }
@@ -101,7 +101,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -115,7 +115,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -211,7 +211,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -231,7 +231,7 @@ at 'ClientOptions.database'
           }) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -257,7 +257,7 @@ at 'ClientOptions.database'
         (new InfluxDBClient('https://localhost:8086?token=my-token') as any)
           ._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -270,7 +270,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         authScheme: 'my-scheme',
@@ -281,7 +281,7 @@ at 'ClientOptions.database'
         (new InfluxDBClient(' https://localhost:8086?token=my-token ') as any)
           ._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -294,7 +294,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         database: 'my-database',
@@ -308,7 +308,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         timeout: 75,
@@ -322,7 +322,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -338,7 +338,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -354,7 +354,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -370,7 +370,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -386,7 +386,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -402,7 +402,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -418,7 +418,7 @@ at 'ClientOptions.database'
           ) as any
         )._options
       ).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -459,7 +459,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = 'https://localhost:8086'
       process.env['INFLUX_TOKEN'] = 'my-token'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -470,7 +470,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_AUTH_SCHEME'] = 'my-scheme'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         authScheme: 'my-scheme',
@@ -481,7 +481,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = ' https://localhost:8086 '
       process.env['INFLUX_TOKEN'] = ' my-token '
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
       })
@@ -492,7 +492,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_DATABASE'] = 'my-database'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         database: 'my-database',
@@ -504,7 +504,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_TIMEOUT'] = '75'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         timeout: 75,
@@ -516,7 +516,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_PRECISION'] = 'us'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -530,7 +530,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_PRECISION'] = 'nanosecond'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -544,7 +544,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_GZIP_THRESHOLD'] = '128'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -558,7 +558,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'true'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -572,7 +572,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'false'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -586,7 +586,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'invalid'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {
@@ -602,7 +602,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_GZIP_THRESHOLD'] = '128'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'true'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
-        ...LOCAL_DEFAULT_ConnectionOptions,
+        ...CONNECTION_TEST_OPTIONS,
         host: 'https://localhost:8086',
         token: 'my-token',
         writeOptions: {

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -667,7 +667,7 @@ at 'ClientOptions.database'
       process.env['INFLUX_HOST'] = 'https://localhost:8086'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_GRPC_OPTIONS'] =
-        'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536';
+        'grpc.max_receive_message_length=65536,grpc.max_send_message_length=65536'
       const expectedOptions = {
         ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -15,7 +15,7 @@ import nock from 'nock'
 
 const CONNECTION_TEST_OPTIONS = {
   ...DEFAULT_ConnectionOptions,
-  grpcOptions: undefined
+  grpcOptions: undefined,
 }
 
 describe('InfluxDB', () => {

--- a/packages/client/test/unit/options.test.ts
+++ b/packages/client/test/unit/options.test.ts
@@ -9,6 +9,8 @@ import {
   WritePrecision,
 } from '../../src'
 
+// TODO update Options tests with new GrpcOptions
+
 describe('ClientOptions', () => {
   afterEach(() => {
     sinon.restore()

--- a/packages/client/test/unit/options.test.ts
+++ b/packages/client/test/unit/options.test.ts
@@ -9,8 +9,6 @@ import {
   WritePrecision,
 } from '../../src'
 
-// TODO update Options tests with new GrpcOptions
-
 describe('ClientOptions', () => {
   afterEach(() => {
     sinon.restore()

--- a/packages/client/test/util.ts
+++ b/packages/client/test/util.ts
@@ -74,7 +74,9 @@ export const expectThrowsAsync = async (
   }
   if (!err) {
     assert.fail(
-      `Method ${method} should throw error ${errName ?? 'Error'}: ${expectedMessage ?? ''}`
+      `Method ${method} should throw error ${errName ?? 'Error'}: ${
+        expectedMessage ?? ''
+      }`
     )
   }
   if (errName) {

--- a/packages/client/test/util.ts
+++ b/packages/client/test/util.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from "chai";
+import {assert, expect} from 'chai'
 import {setLogger} from '../src/util/logger'
 
 let previous: any
@@ -61,41 +61,41 @@ export const unhandledRejections = {
   },
 }
 
-
-export const expectThrowsAsync = async(
-  method: Function,
+export const expectThrowsAsync = async (
+  method: () => void,
   expectedMessage?: string | RegExp,
-  errName?: string,
-) => {
-  let err: any = null;
+  errName?: string
+): Promise<void> => {
+  let err: any = null
   try {
     await method()
   } catch (rejected) {
-    err = rejected;
+    err = rejected
   }
   if (!err) {
-
-    assert.fail(`Method ${method} should throw error ${errName ?? 'Error'}: ${expectedMessage ?? ''}`)
+    assert.fail(
+      `Method ${method} should throw error ${errName ?? 'Error'}: ${expectedMessage ?? ''}`
+    )
   }
-  if(errName) {
-    expect(err.name).to.equal(errName);
+  if (errName) {
+    expect(err.name).to.equal(errName)
   }
-  if(expectedMessage) {
+  if (expectedMessage) {
     if (typeof expectedMessage === 'string') {
-      expect(err["message"]).to.be.equal(expectedMessage)
+      expect(err['message']).to.be.equal(expectedMessage)
     }
     if (expectedMessage instanceof RegExp) {
-      expect(err["message"]).to.match(expectedMessage)
+      expect(err['message']).to.match(expectedMessage)
     }
   }
 }
 
-export const expectResolve = async(
-  method: Function
-)=> {
+export const expectResolve = async (method: () => void): Promise<void> => {
   try {
     await method()
-  } catch(error) {
-    assert.fail(`Method should resolve without error: ${method}.  But caught ${error}`)
+  } catch (error) {
+    assert.fail(
+      `Method should resolve without error: ${method}.  But caught ${error}`
+    )
   }
 }

--- a/packages/client/test/util.ts
+++ b/packages/client/test/util.ts
@@ -1,4 +1,4 @@
-import {expect} from 'chai'
+import { assert, expect } from "chai";
 import {setLogger} from '../src/util/logger'
 
 let previous: any
@@ -59,4 +59,38 @@ export const unhandledRejections = {
     process.off('unhandledRejection', addRejection)
     expect(rejections, 'Unhandled Promise rejections detected').deep.equals([])
   },
+}
+
+
+export const expectThrowsAsync = async(
+  method: Function,
+  message?: string,
+  errName?: string,
+) => {
+  let err: any = null;
+  try {
+    await method()
+  } catch (rejected) {
+    err = rejected;
+  }
+  if (!err) {
+
+    assert.fail(`Method ${method} should throw error ${errName ?? 'Error'}: ${message ?? ''}`)
+  }
+  if(errName) {
+    expect(err.name).to.equal(errName);
+  }
+  if(message){
+    expect(err["message"]).to.be.equal(message)
+  }
+}
+
+export const expectResolve = async(
+  method: Function
+)=> {
+  try {
+    await method()
+  } catch(error) {
+    assert.fail(`Method should resolve without error: ${method}.  But caught ${error}`)
+  }
 }

--- a/packages/client/test/util.ts
+++ b/packages/client/test/util.ts
@@ -64,7 +64,7 @@ export const unhandledRejections = {
 
 export const expectThrowsAsync = async(
   method: Function,
-  message?: string,
+  expectedMessage?: string | RegExp,
   errName?: string,
 ) => {
   let err: any = null;
@@ -75,13 +75,18 @@ export const expectThrowsAsync = async(
   }
   if (!err) {
 
-    assert.fail(`Method ${method} should throw error ${errName ?? 'Error'}: ${message ?? ''}`)
+    assert.fail(`Method ${method} should throw error ${errName ?? 'Error'}: ${expectedMessage ?? ''}`)
   }
   if(errName) {
     expect(err.name).to.equal(errName);
   }
-  if(message){
-    expect(err["message"]).to.be.equal(message)
+  if(expectedMessage) {
+    if (typeof expectedMessage === 'string') {
+      expect(err["message"]).to.be.equal(expectedMessage)
+    }
+    if (expectedMessage instanceof RegExp) {
+      expect(err["message"]).to.match(expectedMessage)
+    }
   }
 }
 


### PR DESCRIPTION
## Proposed Changes

- adds `grpcOptions`...
   - ...to `clientOptions`
   - ...to `queryOptions`
- coordinates `grpcOptions` values between `clientOptions` and `queryOptions`
- ensures `grpcOptions` are passed to `@protocol/grpc-transport`
   - updates `TestServer.ts` to 
      - generates test blob, which can trigger RpcError max response length exceeded 
      - handles a delay for testing timeout exceeded   
- further ensures that `queryTimeout` is applied correctly in `@protocol/grpc-transport`
- adds environment variable `INFLUX_GRPC_OPTIONS`.  

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
