### PR TITLE
chore: set @tmp dependency to minimal 0.2.4 to resolve SA 49

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,13 @@
     "lerna": "^8.0.0",
     "prettier": "^3.0.0",
     "rimraf": "^5.0.0",
-    "typedoc": "^0.28.9"
+    "typedoc": "^0.28.9",
+    "tmp": "^0.2.4"
+  },
+  "overrides": {
+    "external-editor" : {
+      "tmp": "latest"
+    }
   },
   "resolutions": {
     "jackspeak": "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6254,6 +6254,11 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+tmp@^0.2.4:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
+  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
+
 tmp@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"


### PR DESCRIPTION
## Proposed Changes

Force @tmp transitive dependency to minimal release 0.2.4. 

Should fix security alert [49](https://github.com/InfluxCommunity/influxdb3-js/security/dependabot/49)  

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated - is this necessary?
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate - n.a.
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
