### PR TITLE
feat: support partial writes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,13 @@ jobs:
       - checkout
       - init-dependencies
       - run:
+          name: Setup InfluxDB service
+          command: |
+            ./scripts/influxdb-setup.sh \
+              --export-url-as TESTING_INFLUXDB_URL \
+              --export-db-as TESTING_INFLUXDB_DATABASE \
+              --export-token-as TESTING_INFLUXDB_TOKEN
+      - run:
           name: Runs tests with coverage
           command: |
             yarn --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 2.3.0 [unreleased]
 
+### Breaking Changes
+
+1. [#773](https://github.com/InfluxCommunity/influxdb3-js/pull/773): Adds partial write support and aligns write routing with v3 defaults.
+   See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
+   For InfluxDB Clustered, set `useV2Api: true` for writes.
+
 ### Build
 
 1. [#775](https://github.com/InfluxCommunity/influxdb3-js/pull/775): Upgrade typescript to 6.0.3.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,26 @@ await client.write(point, database, undefined, {
 })
 ```
 
+#### Accept partial writes and inspect failed lines
+
+Partial writes are enabled by default.
+Configure `acceptPartial` using client `writeOptions`, per-write options, or
+connection/env (`writeAcceptPartial`, `INFLUX_WRITE_ACCEPT_PARTIAL`).
+
+When only part of a v3 write request is rejected, the client throws
+`PartialWriteError` with structured `lineErrors`.
+If partial writes are disabled (`acceptPartial: false`), a rejected line causes
+the whole batch to be rejected.
+
+#### Compatibility with InfluxDB Clustered
+
+Set `useV2Api: true` to write through the v2 compatibility endpoint.
+You can set it in client `writeOptions`, per-write options, or via
+connection/env (`writeUseV2Api`, `INFLUX_WRITE_USE_V2_API`).
+
+With `useV2Api`, `acceptPartial` is ignored and rejected writes return flat v2
+errors.
+
 ### Query data
 
 To query data stored in InfluxDB, call `client.query` with an SQL query and the database (or bucket) name. To change to using InfluxQL add a QueryOptions object with the type 'influxql' (e.g. `client.query(query, database, { type: 'influxql'})`).

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ You can set it in client `writeOptions`, per-write options, or via
 connection/env (`writeUseV2Api`, `INFLUX_WRITE_USE_V2_API`).
 
 With `useV2Api`, `acceptPartial` is ignored and rejected writes return flat v2
-errors.
+errors. `noSync` cannot be used with `useV2Api`; this combination is rejected
+before request dispatch with:
+`invalid write options: noSync cannot be used with useV2Api`.
 
 ### Query data
 

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -50,7 +50,9 @@ export default class InfluxDBClient {
    *   - timeout - I/O timeout
    *   - precision - timestamp precision when writing data
    *   - gzipThreshold - payload size threshold for gzipping data
+   *   - writeAcceptPartial - allow partial writes when some lines fail
    *   - writeNoSync - skip waiting for WAL persistence on write
+   *   - writeUseV2Api - use /api/v2/write compatibility endpoint
    *
    * @param connectionString - connection string
    */
@@ -67,7 +69,9 @@ export default class InfluxDBClient {
    *   - INFLUX_DATABASE - database (bucket) name
    *   - INFLUX_PRECISION - timestamp precision when writing data
    *   - INFLUX_GZIP_THRESHOLD - payload size threshold for gzipping data
+   *   - INFLUX_WRITE_ACCEPT_PARTIAL - allow partial writes when some lines fail
    *   - INFLUX_WRITE_NO_SYNC - skip waiting for WAL persistence on write
+   *   - INFLUX_WRITE_USE_V2_API - use /api/v2/write compatibility endpoint
    *   - INFLUX_GRPC_OPTIONS - comma separated set of key=value pairs matching @grpc/grpc-js channel options.
    */
   constructor()

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,5 +1,63 @@
 import {Headers} from './results'
 
+export interface PartialWriteLineError {
+  lineNumber: number
+  errorMessage: string
+  originalLine: string
+}
+
+function isV3PartialWriteErrorMessage(errorMessage: unknown): boolean {
+  if (typeof errorMessage !== 'string' || errorMessage.length === 0) {
+    return false
+  }
+  const normalized = errorMessage.toLowerCase()
+  return (
+    normalized.includes('partial write of line protocol occurred') ||
+    normalized.includes('parsing failed for write_lp endpoint')
+  )
+}
+
+function toLineError(item: unknown): PartialWriteLineError | undefined {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) {
+    return undefined
+  }
+  const lineNumber = (item as {line_number?: unknown}).line_number
+  const errorMessage = (item as {error_message?: unknown}).error_message
+  const originalLine = (item as {original_line?: unknown}).original_line
+  if (
+    typeof lineNumber !== 'number' ||
+    !Number.isFinite(lineNumber) ||
+    typeof errorMessage !== 'string' ||
+    errorMessage.length === 0 ||
+    typeof originalLine !== 'string' ||
+    originalLine.length === 0
+  ) {
+    return undefined
+  }
+  return {lineNumber, errorMessage, originalLine}
+}
+
+function parseTypedLineErrors(
+  data: unknown
+): PartialWriteLineError[] | undefined {
+  if (!Array.isArray(data)) {
+    return undefined
+  }
+  const lineErrors: PartialWriteLineError[] = []
+  for (const item of data) {
+    const lineError = toLineError(item)
+    if (!lineError) {
+      return undefined
+    }
+    lineErrors.push(lineError)
+  }
+  return lineErrors.length > 0 ? lineErrors : undefined
+}
+
+function parseSingleLineError(data: unknown): PartialWriteLineError | undefined {
+  return toLineError(data)
+}
+
 function formatErrorMessage(node: any): string | undefined {
   if (!node || typeof node !== 'object' || Array.isArray(node)) {
     return undefined
@@ -11,10 +69,22 @@ function formatErrorMessage(node: any): string | undefined {
 
   const errorText = typeof node.error === 'string' ? node.error : undefined
   const data = node.data
-  if (errorText && Array.isArray(data)) {
+  if (
+    errorText &&
+    isV3PartialWriteErrorMessage(errorText) &&
+    Array.isArray(data)
+  ) {
     const details: string[] = []
     for (const item of data) {
+      if (item === undefined || item === null) {
+        continue
+      }
+      if (typeof item === 'string' && item.length > 0) {
+        details.push(`\t${item}`)
+        continue
+      }
       if (!item || typeof item !== 'object' || Array.isArray(item)) {
+        details.push(`\t${String(item)}`)
         continue
       }
       const lineNumber = item.line_number
@@ -38,11 +108,18 @@ function formatErrorMessage(node: any): string | undefined {
     }
     return errorText
   }
-  if (data && typeof data === 'object' && !Array.isArray(data)) {
+  if (
+    errorText &&
+    isV3PartialWriteErrorMessage(errorText) &&
+    data &&
+    typeof data === 'object' &&
+    !Array.isArray(data)
+  ) {
     const errorMessage = (data as {error_message?: unknown}).error_message
     if (typeof errorMessage === 'string' && errorMessage.length > 0) {
-      return errorMessage
+      return `${errorText}:\n\t${errorMessage}`
     }
+    return errorText
   }
   if (errorText) {
     return errorText
@@ -104,6 +181,59 @@ export class HttpError extends Error {
       this.message = `${statusCode} ${statusMessage} : ${body}`
     }
     this.name = 'HttpError'
+  }
+}
+
+export class PartialWriteError extends HttpError {
+  constructor(
+    statusCode: number,
+    statusMessage: string | undefined,
+    body: string | undefined,
+    contentType: string | undefined | null,
+    headers: Headers | null | undefined,
+    message: string,
+    readonly lineErrors: PartialWriteLineError[]
+  ) {
+    super(statusCode, statusMessage, body, contentType, headers, message)
+    this.name = 'PartialWriteError'
+    Object.setPrototypeOf(this, PartialWriteError.prototype)
+  }
+
+  static fromHttpError(error: HttpError): PartialWriteError | undefined {
+    const bodyJson = error.json
+    if (!bodyJson || typeof bodyJson !== 'object' || Array.isArray(bodyJson)) {
+      return undefined
+    }
+    const errorMessage = (bodyJson as {error?: unknown}).error
+    if (!isV3PartialWriteErrorMessage(errorMessage)) {
+      return undefined
+    }
+    const data = (bodyJson as {data?: unknown}).data
+    const typedArray = parseTypedLineErrors(data)
+    if (typedArray) {
+      return new PartialWriteError(
+        error.statusCode,
+        error.statusMessage,
+        error.body,
+        error.contentType,
+        error.headers,
+        error.message,
+        typedArray
+      )
+    }
+    const single = parseSingleLineError(data)
+    if (single) {
+      return new PartialWriteError(
+        error.statusCode,
+        error.statusMessage,
+        error.body,
+        error.contentType,
+        error.headers,
+        error.message,
+        [single]
+      )
+    }
+    return undefined
   }
 }
 

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -196,7 +196,8 @@ export class PartialWriteError extends HttpError {
     message: string,
     readonly lineErrors: PartialWriteLineError[]
   ) {
-    super(statusCode, statusMessage, body, contentType, headers, message)
+    super(statusCode, statusMessage, body, contentType, headers)
+    this.message = message
     this.name = 'PartialWriteError'
     Object.setPrototypeOf(this, PartialWriteError.prototype)
   }

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -54,7 +54,9 @@ function parseTypedLineErrors(
   return lineErrors.length > 0 ? lineErrors : undefined
 }
 
-function parseSingleLineError(data: unknown): PartialWriteLineError | undefined {
+function parseSingleLineError(
+  data: unknown
+): PartialWriteLineError | undefined {
   return toLineError(data)
 }
 

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -63,8 +63,6 @@ export default class WriteApiImpl implements WriteApi {
     if (self._closed) {
       return Promise.reject(new Error('writeApi: already closed!'))
     }
-    if (lines.length <= 0 || (lines.length === 1 && lines[0] === ''))
-      return Promise.resolve()
 
     const writeOptionsOrDefault: WriteOptions = {
       ...DEFAULT_WriteOptions,
@@ -78,6 +76,8 @@ export default class WriteApiImpl implements WriteApi {
         )
       )
     }
+    if (lines.length <= 0 || (lines.length === 1 && lines[0] === ''))
+      return Promise.resolve()
 
     let resolve: (value: void | PromiseLike<void>) => void
     let reject: (reason?: any) => void

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -73,7 +73,7 @@ export default class WriteApiImpl implements WriteApi {
 
     if (writeOptionsOrDefault.useV2Api && writeOptionsOrDefault.noSync) {
       throw new IllegalArgumentError(
-        'invalid write options: NoSync cannot be used in V2 API'
+        'invalid write options: noSync cannot be used with useV2Api'
       )
     }
 

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -66,13 +66,6 @@ export default class WriteApiImpl implements WriteApi {
     if (lines.length <= 0 || (lines.length === 1 && lines[0] === ''))
       return Promise.resolve()
 
-    let resolve: (value: void | PromiseLike<void>) => void
-    let reject: (reason?: any) => void
-    const promise = new Promise<void>((res, rej) => {
-      resolve = res
-      reject = rej
-    })
-
     const writeOptionsOrDefault: WriteOptions = {
       ...DEFAULT_WriteOptions,
       ...writeOptions,
@@ -83,6 +76,13 @@ export default class WriteApiImpl implements WriteApi {
         'invalid write options: NoSync cannot be used in V2 API'
       )
     }
+
+    let resolve: (value: void | PromiseLike<void>) => void
+    let reject: (reason?: any) => void
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
 
     let responseStatusCode: number | undefined
     let headers: Headers

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -9,7 +9,7 @@ import {
 import {Transport} from '../transport'
 import {Headers} from '../results'
 import {Log} from '../util/logger'
-import {HttpError} from '../errors'
+import {HttpError, IllegalArgumentError, PartialWriteError} from '../errors'
 import {impl} from './implSelector'
 
 export default class WriteApiImpl implements WriteApi {
@@ -33,17 +33,20 @@ export default class WriteApiImpl implements WriteApi {
     let path: string
     const query: string[] = []
     if (org) query.push(`org=${encodeURIComponent(org)}`)
-    if (writeOptions.noSync) {
-      // Setting no_sync=true is supported only in the v3 API.
-      path = `/api/v3/write_lp`
-      query.push(`db=${encodeURIComponent(bucket)}`)
-      query.push(`precision=${precisionToV3ApiString(precision)}`)
-      query.push(`no_sync=true`)
-    } else {
-      // By default, use the v2 API.
+    if (writeOptions.useV2Api) {
       path = `/api/v2/write`
       query.push(`bucket=${encodeURIComponent(bucket)}`)
       query.push(`precision=${precisionToV2ApiString(precision)}`)
+    } else {
+      path = `/api/v3/write_lp`
+      query.push(`db=${encodeURIComponent(bucket)}`)
+      query.push(`precision=${precisionToV3ApiString(precision)}`)
+      if (writeOptions.noSync) {
+        query.push(`no_sync=true`)
+      }
+      if (writeOptions.acceptPartial === false) {
+        query.push(`accept_partial=false`)
+      }
     }
 
     return `${path}?${query.join('&')}`
@@ -74,6 +77,13 @@ export default class WriteApiImpl implements WriteApi {
       ...DEFAULT_WriteOptions,
       ...writeOptions,
     }
+    if (writeOptionsOrDefault.useV2Api && writeOptionsOrDefault.noSync) {
+      return Promise.reject(
+        new IllegalArgumentError(
+          'invalid write options: NoSync cannot be used in V2 API'
+        )
+      )
+    }
 
     let responseStatusCode: number | undefined
     let headers: Headers
@@ -96,19 +106,11 @@ export default class WriteApiImpl implements WriteApi {
           callbacks.complete()
           return
         }
-        if (
-          error instanceof HttpError &&
-          error.statusCode == 405 &&
-          writeOptionsOrDefault.noSync
-        ) {
-          error = new HttpError(
-            error.statusCode,
-            "Server doesn't support write with noSync=true " +
-              '(supported by InfluxDB 3 Core/Enterprise servers only).',
-            error.body,
-            error.contentType,
-            error.headers
-          )
+        if (error instanceof HttpError) {
+          const partialWriteError = PartialWriteError.fromHttpError(error)
+          if (partialWriteError) {
+            error = partialWriteError
+          }
         }
         Log.error(`Write to InfluxDB failed.`, error)
         reject(error)

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -77,11 +77,10 @@ export default class WriteApiImpl implements WriteApi {
       ...DEFAULT_WriteOptions,
       ...writeOptions,
     }
+
     if (writeOptionsOrDefault.useV2Api && writeOptionsOrDefault.noSync) {
-      return Promise.reject(
-        new IllegalArgumentError(
-          'invalid write options: NoSync cannot be used in V2 API'
-        )
+      throw new IllegalArgumentError(
+        'invalid write options: NoSync cannot be used in V2 API'
       )
     }
 

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -108,6 +108,10 @@ export default class WriteApiImpl implements WriteApi {
           return
         }
         if (error instanceof HttpError) {
+          if (responseStatusCode === 405 && !writeOptionsOrDefault.useV2Api) {
+            error.message =
+              "Server doesn't support v3 write API. Set useV2Api=true for v2 compatibility endpoint."
+          }
           const partialWriteError = PartialWriteError.fromHttpError(error)
           if (partialWriteError) {
             error = partialWriteError

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -108,7 +108,8 @@ export default class WriteApiImpl implements WriteApi {
           return
         }
         if (error instanceof HttpError) {
-          if (responseStatusCode === 405 && !writeOptionsOrDefault.useV2Api) {
+          const statusCode = responseStatusCode ?? error.statusCode
+          if (statusCode === 405 && !writeOptionsOrDefault.useV2Api) {
             error.message =
               "Server doesn't support v3 write API. Set useV2Api=true for v2 compatibility endpoint."
           }

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -72,8 +72,10 @@ export default class WriteApiImpl implements WriteApi {
     }
 
     if (writeOptionsOrDefault.useV2Api && writeOptionsOrDefault.noSync) {
-      throw new IllegalArgumentError(
-        'invalid write options: noSync cannot be used with useV2Api'
+      return Promise.reject(
+        new IllegalArgumentError(
+          'invalid write options: noSync cannot be used with useV2Api'
+        )
       )
     }
 

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -108,6 +108,21 @@ export interface WriteOptions {
    * Default value: false.
    */
   noSync?: boolean
+  /**
+   * Allow partial success when some lines in a write batch are rejected.
+   *
+   * Default value: true.
+   */
+  acceptPartial?: boolean
+  /**
+   * Use the v2 compatibility write endpoint.
+   *
+   * This is intended for InfluxDB Clustered compatibility mode.
+   * When enabled, writes use /api/v2/write and ignore acceptPartial.
+   *
+   * Default value: false.
+   */
+  useV2Api?: boolean
   /** default tags
    *
    * @example Default tags using client config
@@ -161,6 +176,8 @@ export const DEFAULT_WriteOptions: WriteOptions = {
   precision: 'ns',
   gzipThreshold: 1000,
   noSync: false,
+  acceptPartial: true,
+  useV2Api: false,
 }
 
 export type QueryType = 'sql' | 'influxql'
@@ -224,6 +241,13 @@ export type WritePrecision = 'ns' | 'us' | 'ms' | 's'
  * Parses connection string into `ClientOptions`.
  * @param connectionString - connection string
  */
+function ensureWriteOptions(options: ClientOptions): WriteOptions {
+  if (!options.writeOptions) {
+    options.writeOptions = {} as WriteOptions
+  }
+  return options.writeOptions as WriteOptions
+}
+
 export function fromConnectionString(connectionString: string): ClientOptions {
   if (!connectionString) {
     throw Error('Connection string not set!')
@@ -248,21 +272,28 @@ export function fromConnectionString(connectionString: string): ClientOptions {
     options.timeout = parseInt(url.searchParams.get('timeout') as string)
   }
   if (url.searchParams.has('precision')) {
-    if (!options.writeOptions) options.writeOptions = {} as WriteOptions
-    options.writeOptions.precision = parsePrecision(
+    ensureWriteOptions(options).precision = parsePrecision(
       url.searchParams.get('precision') as string
     )
   }
   if (url.searchParams.has('gzipThreshold')) {
-    if (!options.writeOptions) options.writeOptions = {} as WriteOptions
-    options.writeOptions.gzipThreshold = parseInt(
+    ensureWriteOptions(options).gzipThreshold = parseInt(
       url.searchParams.get('gzipThreshold') as string
     )
   }
   if (url.searchParams.has('writeNoSync')) {
-    if (!options.writeOptions) options.writeOptions = {} as WriteOptions
-    options.writeOptions.noSync = parseBoolean(
+    ensureWriteOptions(options).noSync = parseBoolean(
       url.searchParams.get('writeNoSync') as string
+    )
+  }
+  if (url.searchParams.has('writeAcceptPartial')) {
+    ensureWriteOptions(options).acceptPartial = parseBoolean(
+      url.searchParams.get('writeAcceptPartial') as string
+    )
+  }
+  if (url.searchParams.has('writeUseV2Api')) {
+    ensureWriteOptions(options).useV2Api = parseBoolean(
+      url.searchParams.get('writeUseV2Api') as string
     )
   }
 
@@ -295,20 +326,29 @@ export function fromEnv(): ClientOptions {
     options.timeout = parseInt(process.env.INFLUX_TIMEOUT.trim())
   }
   if (process.env.INFLUX_PRECISION) {
-    if (!options.writeOptions) options.writeOptions = {} as WriteOptions
-    options.writeOptions.precision = parsePrecision(
+    ensureWriteOptions(options).precision = parsePrecision(
       process.env.INFLUX_PRECISION as string
     )
   }
   if (process.env.INFLUX_GZIP_THRESHOLD) {
-    if (!options.writeOptions) options.writeOptions = {} as WriteOptions
-    options.writeOptions.gzipThreshold = parseInt(
+    ensureWriteOptions(options).gzipThreshold = parseInt(
       process.env.INFLUX_GZIP_THRESHOLD
     )
   }
   if (process.env.INFLUX_WRITE_NO_SYNC) {
-    if (!options.writeOptions) options.writeOptions = {} as WriteOptions
-    options.writeOptions.noSync = parseBoolean(process.env.INFLUX_WRITE_NO_SYNC)
+    ensureWriteOptions(options).noSync = parseBoolean(
+      process.env.INFLUX_WRITE_NO_SYNC
+    )
+  }
+  if (process.env.INFLUX_WRITE_ACCEPT_PARTIAL) {
+    ensureWriteOptions(options).acceptPartial = parseBoolean(
+      process.env.INFLUX_WRITE_ACCEPT_PARTIAL
+    )
+  }
+  if (process.env.INFLUX_WRITE_USE_V2_API) {
+    ensureWriteOptions(options).useV2Api = parseBoolean(
+      process.env.INFLUX_WRITE_USE_V2_API
+    )
   }
   if (process.env.INFLUX_GRPC_OPTIONS) {
     const optionSets = process.env.INFLUX_GRPC_OPTIONS.split(',')

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -237,10 +237,6 @@ export interface ClientOptions extends ConnectionOptions {
  */
 export type WritePrecision = 'ns' | 'us' | 'ms' | 's'
 
-/**
- * Parses connection string into `ClientOptions`.
- * @param connectionString - connection string
- */
 function ensureWriteOptions(options: ClientOptions): WriteOptions {
   if (!options.writeOptions) {
     options.writeOptions = {} as WriteOptions
@@ -248,6 +244,10 @@ function ensureWriteOptions(options: ClientOptions): WriteOptions {
   return options.writeOptions as WriteOptions
 }
 
+/**
+ * Parses connection string into `ClientOptions`.
+ * @param connectionString - connection string
+ */
 export function fromConnectionString(connectionString: string): ClientOptions {
   if (!connectionString) {
     throw Error('Connection string not set!')

--- a/packages/client/test/integration/e2e.test.ts
+++ b/packages/client/test/integration/e2e.test.ts
@@ -1,7 +1,13 @@
 import NodeHttpTransport from '../../src/impl/node/NodeHttpTransport'
 import nock from 'nock'
 import {expect} from 'chai'
-import {InfluxDBClient, Point, PointValues} from '../../src'
+import {
+  HttpError,
+  InfluxDBClient,
+  PartialWriteError,
+  Point,
+  PointValues,
+} from '../../src'
 import {rejects} from 'assert'
 import * as http from 'node:http'
 import {iterateTestData, sendTestData} from '../util'
@@ -572,6 +578,88 @@ describe('e2e test', () => {
       }
       expect(count).to.be.greaterThan(0)
     }).timeout(7_000)
+
+    it('reports partial write details when acceptPartial=true (default)', async () => {
+      const {database, token, url} = getEnvVariables()
+      const client = new InfluxDBClient({
+        host: url,
+        token,
+      })
+
+      const lp = [
+        'home,room=Sunroom temp=96 1735545600',
+        'home,room=Sunroom temp="hi" 1735545610',
+        'home,room=Sunroom temp=88i 1735545620',
+      ].join('\n')
+
+      try {
+        await client.write(lp, database)
+        expect.fail('failure expected')
+      } catch (e: any) {
+        expect(e).instanceOf(PartialWriteError)
+        expect(e.message).to.include('partial write of line protocol occurred')
+        expect(e.lineErrors).to.have.length(2)
+        expect(e.lineErrors[0].lineNumber).to.equal(2)
+        expect(e.lineErrors[1].lineNumber).to.equal(3)
+      } finally {
+        await client.close()
+      }
+    }).timeout(10_000)
+
+    it('reports write_lp parsing failure details when acceptPartial=false', async () => {
+      const {database, token, url} = getEnvVariables()
+      const client = new InfluxDBClient({
+        host: url,
+        token,
+      })
+
+      const lp = [
+        'home,room=Sunroom temp=96 1735545600',
+        'home,room=Sunroom temp="hi" 1735545610',
+        'home,room=Sunroom temp=88i 1735545620',
+      ].join('\n')
+
+      try {
+        await client.write(lp, database, undefined, {
+          acceptPartial: false,
+        })
+        expect.fail('failure expected')
+      } catch (e: any) {
+        expect(e).instanceOf(PartialWriteError)
+        expect(e.message).to.include('parsing failed for write_lp endpoint')
+        expect(e.lineErrors).to.have.length(1)
+        expect(e.lineErrors[0].lineNumber).to.equal(2)
+      } finally {
+        await client.close()
+      }
+    }).timeout(10_000)
+
+    it('uses v2 compatibility endpoint and returns non-structured error', async () => {
+      const {database, token, url} = getEnvVariables()
+      const client = new InfluxDBClient({
+        host: url,
+        token,
+      })
+
+      const lp = [
+        'home,room=Sunroom temp=96 1735545600',
+        'home,room=Sunroom temp="hi" 1735545610',
+        'home,room=Sunroom temp=88i 1735545620',
+      ].join('\n')
+
+      try {
+        await client.write(lp, database, undefined, {
+          useV2Api: true,
+        })
+        expect.fail('failure expected')
+      } catch (e: any) {
+        expect(e).instanceOf(HttpError)
+        expect(e).not.instanceOf(PartialWriteError)
+        expect(e.message).to.include('line protocol parse failed')
+      } finally {
+        await client.close()
+      }
+    }).timeout(10_000)
   })
   describe('with node http', () => {
     const port = 65535

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -459,11 +459,43 @@ at 'ClientOptions.database'
         } as WriteOptions,
       })
     })
-    it('is created with precision, gzip threshold and writeNoSync', () => {
+    it('creates instance with acceptPartial=false', () => {
       expect(
         (
           new InfluxDBClient(
-            'https://localhost:8086?token=my-token&precision=us&gzipThreshold=128&writeNoSync=true'
+            'https://localhost:8086?token=my-token&writeAcceptPartial=false'
+          ) as any
+        )._options
+      ).to.deep.equal({
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        writeOptions: {
+          acceptPartial: false,
+        } as WriteOptions,
+      })
+    })
+    it('creates instance with useV2Api=true', () => {
+      expect(
+        (
+          new InfluxDBClient(
+            'https://localhost:8086?token=my-token&writeUseV2Api=true'
+          ) as any
+        )._options
+      ).to.deep.equal({
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        writeOptions: {
+          useV2Api: true,
+        } as WriteOptions,
+      })
+    })
+    it('is created with precision, gzip threshold, writeNoSync, writeAcceptPartial and writeUseV2Api', () => {
+      expect(
+        (
+          new InfluxDBClient(
+            'https://localhost:8086?token=my-token&precision=us&gzipThreshold=128&writeNoSync=true&writeAcceptPartial=false&writeUseV2Api=true'
           ) as any
         )._options
       ).to.deep.equal({
@@ -474,6 +506,8 @@ at 'ClientOptions.database'
           precision: 'us' as WritePrecision,
           gzipThreshold: 128,
           noSync: true,
+          acceptPartial: false,
+          useV2Api: true,
         } as WriteOptions,
       })
     })
@@ -489,6 +523,8 @@ at 'ClientOptions.database'
       delete process.env['INFLUX_PRECISION']
       delete process.env['INFLUX_GZIP_THRESHOLD']
       delete process.env['INFLUX_WRITE_NO_SYNC']
+      delete process.env['INFLUX_WRITE_ACCEPT_PARTIAL']
+      delete process.env['INFLUX_WRITE_USE_V2_API']
       delete process.env['INFLUX_GRPC_OPTIONS']
     }
     it('fails on missing host', () => {
@@ -644,13 +680,43 @@ at 'ClientOptions.database'
         } as WriteOptions,
       })
     })
-    it('is created with host, token, precision, gzip threshold and write-no-sync', () => {
+    it('creates instance with acceptPartial=false', () => {
+      clear()
+      process.env['INFLUX_HOST'] = 'https://localhost:8086'
+      process.env['INFLUX_TOKEN'] = 'my-token'
+      process.env['INFLUX_WRITE_ACCEPT_PARTIAL'] = 'false'
+      expect((new InfluxDBClient() as any)._options).to.deep.equal({
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        writeOptions: {
+          acceptPartial: false,
+        } as WriteOptions,
+      })
+    })
+    it('creates instance with useV2Api=true', () => {
+      clear()
+      process.env['INFLUX_HOST'] = 'https://localhost:8086'
+      process.env['INFLUX_TOKEN'] = 'my-token'
+      process.env['INFLUX_WRITE_USE_V2_API'] = 'true'
+      expect((new InfluxDBClient() as any)._options).to.deep.equal({
+        ...DEFAULT_ConnectionOptions,
+        host: 'https://localhost:8086',
+        token: 'my-token',
+        writeOptions: {
+          useV2Api: true,
+        } as WriteOptions,
+      })
+    })
+    it('is created with host, token, precision, gzip threshold, write-no-sync, write-accept-partial and write-use-v2-api', () => {
       clear()
       process.env['INFLUX_HOST'] = 'https://localhost:8086'
       process.env['INFLUX_TOKEN'] = 'my-token'
       process.env['INFLUX_PRECISION'] = 'us'
       process.env['INFLUX_GZIP_THRESHOLD'] = '128'
       process.env['INFLUX_WRITE_NO_SYNC'] = 'true'
+      process.env['INFLUX_WRITE_ACCEPT_PARTIAL'] = 'false'
+      process.env['INFLUX_WRITE_USE_V2_API'] = 'true'
       expect((new InfluxDBClient() as any)._options).to.deep.equal({
         ...DEFAULT_ConnectionOptions,
         host: 'https://localhost:8086',
@@ -659,6 +725,8 @@ at 'ClientOptions.database'
           precision: 'us' as WritePrecision,
           gzipThreshold: 128,
           noSync: true,
+          acceptPartial: false,
+          useV2Api: true,
         } as WriteOptions,
       })
     })
@@ -809,7 +877,7 @@ at 'ClientOptions.database'
       let special: any
       let oneOff: any
       nock('http://test:8086')
-        .post(`/api/v2/write?bucket=${DATABASE}&precision=ns`)
+        .post(`/api/v3/write_lp?db=${DATABASE}&precision=nanosecond`)
         .reply(
           204,
           function (_uri, _body, callback) {

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -328,84 +328,47 @@ describe('Write', () => {
       expect(universal).equals('substance')
       expect(particular).equals('attribute')
     })
-    it('calls v3 api by default', async () => {
-      useSubject({})
-      nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
-        .reply(function (_uri) {
-          return [204, '', {'retry-after': '1'}]
-        })
-        .persist()
+    ;[
+      {
+        title: 'calls v3 api by default',
+        writeOptions: {},
+        path: WRITE_PATH_NS,
+      },
+      {
+        title: 'calls v3 api if noSync=false',
+        writeOptions: {noSync: false},
+        path: WRITE_PATH_NS,
+      },
+      {
+        title: 'calls v3 api if noSync=true',
+        writeOptions: {noSync: true},
+        path: WRITE_PATH_NS_V3_NO_SYNC,
+      },
+      {
+        title: 'calls v3 api with accept_partial=false',
+        writeOptions: {acceptPartial: false},
+        path: WRITE_PATH_NS_V3_ACCEPT_PARTIAL_FALSE,
+      },
+      {
+        title: 'calls v2 api if useV2Api=true',
+        writeOptions: {useV2Api: true},
+        path: WRITE_PATH_NS_V2,
+      },
+    ].forEach(({title, writeOptions, path}) => {
+      it(title, async () => {
+        useSubject(writeOptions)
+        nock(clientOptions.host)
+          .post(path)
+          .reply(function (_uri) {
+            return [204, {}]
+          })
+          .persist()
 
-      await subject.write('test value=1', DATABASE)
-      expect(logs.error).to.length(0)
-      expect(logs.warn).to.length(0)
-      expect(nock.isDone()).to.be.true
-    })
-    it('calls v3 api if noSync=false', async () => {
-      useSubject({
-        noSync: false,
+        await subject.write('test value=1', DATABASE)
+        expect(logs.error).to.length(0)
+        expect(logs.warn).to.length(0)
+        expect(nock.isDone()).to.be.true
       })
-      nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
-        .reply(function (_uri) {
-          return [204, '', {'retry-after': '1'}]
-        })
-        .persist()
-
-      await subject.write('test value=1', DATABASE)
-      expect(logs.error).to.length(0)
-      expect(logs.warn).to.length(0)
-      expect(nock.isDone()).to.be.true
-    })
-    it('calls v3 api if noSync=true', async () => {
-      useSubject({
-        noSync: true,
-      })
-      nock(clientOptions.host)
-        .post(WRITE_PATH_NS_V3_NO_SYNC)
-        .reply(function (_uri) {
-          return [204, {}]
-        })
-        .persist()
-
-      await subject.write('test value=1', DATABASE)
-      expect(logs.error).to.length(0)
-      expect(logs.warn).to.length(0)
-      expect(nock.isDone()).to.be.true
-    })
-    it('calls v3 api with accept_partial=false', async () => {
-      useSubject({
-        acceptPartial: false,
-      })
-      nock(clientOptions.host)
-        .post(WRITE_PATH_NS_V3_ACCEPT_PARTIAL_FALSE)
-        .reply(function (_uri) {
-          return [204, {}]
-        })
-        .persist()
-
-      await subject.write('test value=1', DATABASE)
-      expect(logs.error).to.length(0)
-      expect(logs.warn).to.length(0)
-      expect(nock.isDone()).to.be.true
-    })
-
-    it('calls v2 api if useV2Api=true', async () => {
-      useSubject({
-        useV2Api: true,
-      })
-      nock(clientOptions.host)
-        .post(WRITE_PATH_NS_V2)
-        .reply(function (_uri) {
-          return [204, {}]
-        })
-        .persist()
-
-      await subject.write('test value=1', DATABASE)
-      expect(logs.error).to.length(0)
-      expect(logs.warn).to.length(0)
-      expect(nock.isDone()).to.be.true
     })
 
     it('fails validation if useV2Api=true and noSync=true', async () => {

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -420,7 +420,7 @@ describe('Write', () => {
         .catch((e) => {
           expect(e).instanceOf(IllegalArgumentError)
           expect(e.message).equals(
-            'invalid write options: NoSync cannot be used in V2 API'
+            'invalid write options: noSync cannot be used with useV2Api'
           )
         })
       expect(logs.error).to.length(0)

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -377,15 +377,24 @@ describe('Write', () => {
         noSync: true,
       })
 
-      await subject
-        .write('test value=1', DATABASE)
-        .then(() => expect.fail('failure expected'))
-        .catch((e) => {
-          expect(e).instanceOf(IllegalArgumentError)
-          expect(e.message).equals(
-            'invalid write options: noSync cannot be used with useV2Api'
-          )
-        })
+      const cases = [
+        {title: 'non-empty payload', payload: 'test value=1'},
+        {title: 'empty string payload', payload: ''},
+        {title: 'empty array payload', payload: [] as string[]},
+      ]
+
+      for (const c of cases) {
+        await subject
+          .write(c.payload, DATABASE)
+          .then(() => expect.fail(`failure expected for ${c.title}`))
+          .catch((e) => {
+            expect(e).instanceOf(IllegalArgumentError)
+            expect(e.message).equals(
+              'invalid write options: noSync cannot be used with useV2Api'
+            )
+          })
+      }
+
       expect(logs.error).to.length(0)
       expect(logs.warn).to.length(0)
     })

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -3,6 +3,8 @@ import nock from 'nock' // WARN: nock must be imported before NodeHttpTransport,
 import {
   ClientOptions,
   HttpError,
+  IllegalArgumentError,
+  PartialWriteError,
   WriteOptions,
   Point,
   InfluxDBClient,
@@ -20,8 +22,10 @@ const clientOptions: ClientOptions = {
 const DATABASE = 'database'
 const PRECISION: WritePrecision = 's'
 
-const WRITE_PATH_NS = `/api/v2/write?bucket=${DATABASE}&precision=ns`
+const WRITE_PATH_NS = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond`
 const WRITE_PATH_NS_V3_NO_SYNC = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond&no_sync=true`
+const WRITE_PATH_NS_V3_ACCEPT_PARTIAL_FALSE = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond&accept_partial=false`
+const WRITE_PATH_NS_V2 = `/api/v2/write?bucket=${DATABASE}&precision=ns`
 
 function createApi(options: Partial<WriteOptions>): InfluxDBClient {
   return new InfluxDBClient({
@@ -324,7 +328,7 @@ describe('Write', () => {
       expect(universal).equals('substance')
       expect(particular).equals('attribute')
     })
-    it('calls v2 api if noSync is not provided', async () => {
+    it('calls v3 api by default', async () => {
       useSubject({})
       nock(clientOptions.host)
         .post(WRITE_PATH_NS)
@@ -338,7 +342,7 @@ describe('Write', () => {
       expect(logs.warn).to.length(0)
       expect(nock.isDone()).to.be.true
     })
-    it('calls v2 api if noSync=false', async () => {
+    it('calls v3 api if noSync=false', async () => {
       useSubject({
         noSync: false,
       })
@@ -370,14 +374,85 @@ describe('Write', () => {
       expect(logs.warn).to.length(0)
       expect(nock.isDone()).to.be.true
     })
-    it('fails if noSync=true but server supports only v2 api', async () => {
+    it('calls v3 api with accept_partial=false', async () => {
       useSubject({
-        noSync: true,
+        acceptPartial: false,
       })
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS_V3_NO_SYNC)
+        .post(WRITE_PATH_NS_V3_ACCEPT_PARTIAL_FALSE)
         .reply(function (_uri) {
-          return [405, '']
+          return [204, {}]
+        })
+        .persist()
+
+      await subject.write('test value=1', DATABASE)
+      expect(logs.error).to.length(0)
+      expect(logs.warn).to.length(0)
+      expect(nock.isDone()).to.be.true
+    })
+
+    it('calls v2 api if useV2Api=true', async () => {
+      useSubject({
+        useV2Api: true,
+      })
+      nock(clientOptions.host)
+        .post(WRITE_PATH_NS_V2)
+        .reply(function (_uri) {
+          return [204, {}]
+        })
+        .persist()
+
+      await subject.write('test value=1', DATABASE)
+      expect(logs.error).to.length(0)
+      expect(logs.warn).to.length(0)
+      expect(nock.isDone()).to.be.true
+    })
+
+    it('fails validation if useV2Api=true and noSync=true', async () => {
+      useSubject({
+        useV2Api: true,
+        noSync: true,
+      })
+
+      await subject
+        .write('test value=1', DATABASE)
+        .then(() => expect.fail('failure expected'))
+        .catch((e) => {
+          expect(e).instanceOf(IllegalArgumentError)
+          expect(e.message).equals(
+            'invalid write options: NoSync cannot be used in V2 API'
+          )
+        })
+      expect(logs.error).to.length(0)
+      expect(logs.warn).to.length(0)
+    })
+
+    it('returns PartialWriteError for v3 partial write data array', async () => {
+      useSubject({})
+      nock(clientOptions.host)
+        .post(WRITE_PATH_NS)
+        .reply(function (_uri) {
+          return [
+            400,
+            JSON.stringify({
+              error: 'partial write of line protocol occurred',
+              data: [
+                {
+                  error_message:
+                    "invalid column type for column 'temp', expected iox::column_type::field::float, got iox::column_type::field::string",
+                  line_number: 2,
+                  original_line: 'home,room=Sunroom te',
+                },
+                {
+                  error_message:
+                    "invalid column type for column 'temp', expected iox::column_type::field::float, got iox::column_type::field::integer",
+                  line_number: 3,
+                  original_line: 'home,room=Sunroom te',
+                },
+              ],
+            }),
+            {'content-type': 'application/json'},
+          ]
         })
         .persist()
 
@@ -385,17 +460,78 @@ describe('Write', () => {
         .write('test value=1', DATABASE)
         .then(() => expect.fail('failure expected'))
         .catch((e) => {
-          expect(e).to.be.ok
+          expect(e).instanceOf(PartialWriteError)
+          expect(e.lineErrors).to.have.length(2)
         })
-      expect(logs.error).has.length(1)
-      expect(logs.error[0][0]).equals('Write to InfluxDB failed.')
-      expect(logs.error[0][1]).instanceOf(HttpError)
-      expect(logs.error[0][1].statusCode).equals(405)
-      expect(logs.error[0][1].message).contain(
-        `Server doesn't support write with noSync=true (supported by InfluxDB 3 Core/Enterprise servers only).`
-      )
+      expect(logs.error).to.length(1)
       expect(logs.warn).to.length(0)
+      expect(nock.isDone()).to.be.true
+    })
 
+    it('returns PartialWriteError for v3 write_lp parsing failed object data', async () => {
+      useSubject({
+        acceptPartial: false,
+      })
+      nock(clientOptions.host)
+        .post(WRITE_PATH_NS_V3_ACCEPT_PARTIAL_FALSE)
+        .reply(function (_uri) {
+          return [
+            400,
+            JSON.stringify({
+              error: 'parsing failed for write_lp endpoint',
+              data: {
+                error_message:
+                  "invalid column type for column 'temp', expected iox::column_type::field::float, got iox::column_type::field::string",
+                line_number: 2,
+                original_line: 'home,room=Sunroom te',
+              },
+            }),
+            {'content-type': 'application/json'},
+          ]
+        })
+        .persist()
+
+      await subject
+        .write('test value=1', DATABASE)
+        .then(() => expect.fail('failure expected'))
+        .catch((e) => {
+          expect(e).instanceOf(PartialWriteError)
+          expect(e.lineErrors).to.have.length(1)
+          expect(e.message).contains('parsing failed for write_lp endpoint')
+        })
+      expect(logs.error).to.length(1)
+      expect(logs.warn).to.length(0)
+      expect(nock.isDone()).to.be.true
+    })
+
+    it('returns HttpError for v2 compatibility with rejected write', async () => {
+      useSubject({
+        useV2Api: true,
+      })
+      nock(clientOptions.host)
+        .post(WRITE_PATH_NS_V2)
+        .reply(function (_uri) {
+          return [
+            400,
+            JSON.stringify({
+              code: 'invalid',
+              message:
+                "write buffer error: line protocol parse failed: invalid column type for column 'temp', expected iox::column_type::field::float, got iox::column_type::field::string",
+            }),
+            {'content-type': 'application/json'},
+          ]
+        })
+        .persist()
+
+      await subject
+        .write('test value=1', DATABASE)
+        .then(() => expect.fail('failure expected'))
+        .catch((e) => {
+          expect(e).instanceOf(HttpError)
+          expect(e).not.instanceOf(PartialWriteError)
+        })
+      expect(logs.error).to.length(1)
+      expect(logs.warn).to.length(0)
       expect(nock.isDone()).to.be.true
     })
   })

--- a/packages/client/test/unit/errors.test.ts
+++ b/packages/client/test/unit/errors.test.ts
@@ -161,11 +161,10 @@ describe('errors', () => {
     })
   })
   describe('PartialWriteError', () => {
-    it('is created from typed data array', () => {
-      const error = new HttpError(
-        400,
-        'Bad Request',
-        JSON.stringify({
+    ;[
+      {
+        title: 'is created from typed data array',
+        body: {
           error: 'partial write of line protocol occurred',
           data: [
             {
@@ -174,48 +173,60 @@ describe('errors', () => {
               original_line: 'm,t=a value=1',
             },
           ],
-        }),
-        'application/json'
-      )
-      const partial = PartialWriteError.fromHttpError(error)
-      expect(partial).instanceOf(PartialWriteError)
-      expect(partial?.lineErrors).to.deep.equal([
-        {
-          lineNumber: 2,
-          errorMessage: 'bad value',
-          originalLine: 'm,t=a value=1',
         },
-      ])
-    })
-    it('is created from single data object', () => {
-      const error = new HttpError(
-        400,
-        'Bad Request',
-        JSON.stringify({
+        expectPartial: true,
+        expectedLineErrors: [
+          {
+            lineNumber: 2,
+            errorMessage: 'bad value',
+            originalLine: 'm,t=a value=1',
+          },
+        ],
+      },
+      {
+        title: 'is created from single data object',
+        body: {
           error: 'parsing failed for write_lp endpoint',
           data: {
             error_message: 'bad value',
             line_number: 2,
             original_line: 'm,t=a value=1',
           },
-        }),
-        'application/json'
-      )
-      const partial = PartialWriteError.fromHttpError(error)
-      expect(partial).instanceOf(PartialWriteError)
-      expect(partial?.lineErrors).to.have.length(1)
-    })
-    it('is not created for non-partial-write error', () => {
-      const error = new HttpError(
-        400,
-        'Bad Request',
-        JSON.stringify({
+        },
+        expectPartial: true,
+        expectedLineErrors: [
+          {
+            lineNumber: 2,
+            errorMessage: 'bad value',
+            originalLine: 'm,t=a value=1',
+          },
+        ],
+      },
+      {
+        title: 'is not created for non-partial-write error',
+        body: {
           code: 'invalid',
           message: 'write buffer error: line protocol parse failed: bad value',
-        }),
-        'application/json'
-      )
-      expect(PartialWriteError.fromHttpError(error)).to.equal(undefined)
+        },
+        expectPartial: false,
+      },
+    ].forEach(({title, body, expectPartial, expectedLineErrors}) => {
+      it(title, () => {
+        const error = new HttpError(
+          400,
+          'Bad Request',
+          JSON.stringify(body),
+          'application/json'
+        )
+        const partial = PartialWriteError.fromHttpError(error)
+        expect(!!partial).to.equal(expectPartial)
+        if (expectPartial) {
+          expect(partial).instanceOf(PartialWriteError)
+          expect(partial?.lineErrors).to.deep.equal(expectedLineErrors)
+        } else {
+          expect(partial).to.equal(undefined)
+        }
+      })
     })
   })
 })

--- a/packages/client/test/unit/errors.test.ts
+++ b/packages/client/test/unit/errors.test.ts
@@ -5,6 +5,7 @@ import {
   RequestTimedOutError,
   AbortError,
   IllegalArgumentError,
+  PartialWriteError,
 } from '../../src'
 
 describe('errors', () => {
@@ -64,7 +65,7 @@ describe('errors', () => {
           '{"error": "parsing failed for write_lp endpoint", "data": {"error_message": "invalid field value in line protocol for field \'value\' on line 0"}}'
         ).message
       ).equals(
-        "invalid field value in line protocol for field 'value' on line 0"
+        "parsing failed for write_lp endpoint:\n\tinvalid field value in line protocol for field 'value' on line 0"
       )
     })
     it('verifies v3 error format with code and message', () => {
@@ -126,6 +127,15 @@ describe('errors', () => {
       )
       expect(message).to.include('testa6a3ad v=1 17702')
     })
+    it('verifies v3 write error message with untyped data fallback details', () => {
+      const body = JSON.stringify({
+        error: 'partial write of line protocol occurred',
+        data: ['bad line', true, null],
+      })
+      expect(new HttpError(400, 'Bad Request', body).message).equals(
+        'partial write of line protocol occurred:\n\tbad line\n\ttrue'
+      )
+    })
   })
   describe('http error values', () => {
     it('propagate headers', () => {
@@ -148,6 +158,64 @@ describe('errors', () => {
       } else {
         expect.fail('httpError.headers should be defined')
       }
+    })
+  })
+  describe('PartialWriteError', () => {
+    it('is created from typed data array', () => {
+      const error = new HttpError(
+        400,
+        'Bad Request',
+        JSON.stringify({
+          error: 'partial write of line protocol occurred',
+          data: [
+            {
+              error_message: 'bad value',
+              line_number: 2,
+              original_line: 'm,t=a value=1',
+            },
+          ],
+        }),
+        'application/json'
+      )
+      const partial = PartialWriteError.fromHttpError(error)
+      expect(partial).instanceOf(PartialWriteError)
+      expect(partial?.lineErrors).to.deep.equal([
+        {
+          lineNumber: 2,
+          errorMessage: 'bad value',
+          originalLine: 'm,t=a value=1',
+        },
+      ])
+    })
+    it('is created from single data object', () => {
+      const error = new HttpError(
+        400,
+        'Bad Request',
+        JSON.stringify({
+          error: 'parsing failed for write_lp endpoint',
+          data: {
+            error_message: 'bad value',
+            line_number: 2,
+            original_line: 'm,t=a value=1',
+          },
+        }),
+        'application/json'
+      )
+      const partial = PartialWriteError.fromHttpError(error)
+      expect(partial).instanceOf(PartialWriteError)
+      expect(partial?.lineErrors).to.have.length(1)
+    })
+    it('is not created for non-partial-write error', () => {
+      const error = new HttpError(
+        400,
+        'Bad Request',
+        JSON.stringify({
+          code: 'invalid',
+          message: 'write buffer error: line protocol parse failed: bad value',
+        }),
+        'application/json'
+      )
+      expect(PartialWriteError.fromHttpError(error)).to.equal(undefined)
     })
   })
 })

--- a/packages/client/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/client/test/unit/impl/browser/FetchTransport.test.ts
@@ -601,8 +601,12 @@ describe('FetchTransport', () => {
         },
         spy
       )
-      // wait for resume being called
-      await waitForCondition(() => cancellable && resume)
+      // wait for resume/cancellable hooks to be wired (can be slower under CI load)
+      await waitForCondition(
+        () => cancellable && resume,
+        'resume and cancellable are set',
+        1000
+      )
       expect(spy.next.callCount).equals(1)
       cancellable?.cancel()
     })

--- a/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -591,8 +591,12 @@ describe('NodeHttpTransport', () => {
         },
         spy
       )
-      // wait for resume being called
-      await waitForCondition(() => cancellable && resume)
+      // wait for resume/cancellable hooks to be wired (can be slower under CI load)
+      await waitForCondition(
+        () => cancellable && resume,
+        'resume and cancellable are set',
+        1000
+      )
       expect(spy.next.callCount).equals(1)
       cancellable?.cancel()
       await waitForCondition(


### PR DESCRIPTION
## Proposed Changes

Adds partial-write support with structured error details in `PartialWriteError`, including per-line `lineNumber`, `errorMessage`, and `originalLine` so callers can decide whether to drop/retry/fix specific lines in a batch.

  This also aligns write routing with the rollout contract:

  - Default write endpoint is now `/api/v3/write_lp`
  - `acceptPartial` defaults to `true` (server default behavior)
  - `accept_partial=false` is sent only when partial writes are explicitly disabled
  - New compatibility option `useV2Api` routes writes to `/api/v2/write` for Clustered/v2-compatible backends

  Configuration surfaces now include:

  - Write option: `acceptPartial`, `useV2Api`
  - Client config / connection string keys: `writeAcceptPartial`, `writeUseV2Api`
  - Environment variables: `INFLUX_WRITE_ACCEPT_PARTIAL`, `INFLUX_WRITE_USE_V2_API`

  Validation:

  - `useV2Api=true` with `noSync=true` is rejected before request dispatch.

  See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) in InfluxDB documentation.

Example:
```ts
const client = new InfluxDBClient({
  host: 'http://localhost:8181',
  token: 'YOUR_TOKEN',
  database: 'my_db',
})

try {
  await client.write(lp) // acceptPartial=true by default
} catch (err) {
  if (err instanceof PartialWriteError) {
    for (const lineErr of err.lineErrors) {
      console.log(
        `line ${lineErr.lineNumber} failed: ${lineErr.errorMessage} (${lineErr.originalLine})`
      )
    }
  } else {
    console.log(err)
  }
}
```

Optional v2 compatibility mode:

```ts
const client = new InfluxDBClient({
  ...
  writeOptions: {
    useV2Api: true,
  },
})

await client.write(lp)
```
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)