### PR TITLE
test: send correct time unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
    See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
    For InfluxDB Clustered, set `useV2Api: true` for writes.
 
+### Features
+
+1. [#790](https://github.com/InfluxCommunity/influxdb3-js/pull/790): When setting Point timestamp to `new Date()`, the timestamp sent to the servers will be converted to the precision set in `WriteOptions`.
+
 ### Build
 
 1. [#775](https://github.com/InfluxCommunity/influxdb3-js/pull/775): Upgrade typescript to 6.0.3.

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -198,7 +198,12 @@ export default class InfluxDBClient {
     const options = this._mergeWriteOptions(writeOptions)
 
     await this._writeApi.doWrite(
-      writableDataToLineProtocol(data, options?.defaultTags, options?.tagOrder),
+      writableDataToLineProtocol(
+        data,
+        options?.defaultTags,
+        options?.tagOrder,
+        options?.precision
+      ),
       database ??
         this._options.database ??
         throwReturn(new Error(argumentErrorMessage)),

--- a/packages/client/src/util/generics.ts
+++ b/packages/client/src/util/generics.ts
@@ -1,5 +1,6 @@
 import {Point} from '../Point'
 import {isArrayLike, isDefined} from './common'
+import {WritePrecision} from '../options'
 
 /**
  * The `WritableData` type represents different types of data that can be written.
@@ -14,7 +15,8 @@ export type WritableData = ArrayLike<string> | ArrayLike<Point> | string | Point
 export const writableDataToLineProtocol = (
   data: WritableData,
   defaultTags?: {[key: string]: string},
-  tagOrder?: string[]
+  tagOrder?: string[],
+  precision?: WritePrecision
 ): string[] => {
   const arrayData = (
     isArrayLike(data) && typeof data !== 'string'
@@ -28,6 +30,10 @@ export const writableDataToLineProtocol = (
   return isLine
     ? (arrayData as string[])
     : (arrayData as Point[])
-        .map((p) => p.toLineProtocol(undefined, defaultTags, tagOrder))
+        .map((p) => {
+          return p.getTimestamp() instanceof Date
+            ? p.toLineProtocol(precision, defaultTags, tagOrder)
+            : p.toLineProtocol(undefined, defaultTags, tagOrder)
+        })
         .filter(isDefined)
 }

--- a/packages/client/src/util/generics.ts
+++ b/packages/client/src/util/generics.ts
@@ -11,7 +11,20 @@ import {WritePrecision} from '../options'
  * - `string`: Represents lines of the [Line Protocol](https://bit.ly/2QL99fu).
  */
 export type WritableData = ArrayLike<string> | ArrayLike<Point> | string | Point
-
+/**
+ * Convert `WritableData` to an array of lines of [Line Protocol](https://bit.ly/2QL99fu)).
+ * If the data is an array of `Point` objects, it will be converted to lines of Line Protocol.
+ * If the data is a single `Point` object, it will be converted to a single line of Line Protocol.
+ * If the data is an array of lines of Line Protocol, it will be returned as is.
+ *
+ * @param data - data to write
+ * @param defaultTags - the default tags to apply to all points.
+ * @param tagOrder - preferred order of tags in line protocol serialization.
+ * Tags listed here are written first, in the same order.
+ * The remaining tags are appended in lexicographical order.
+ * This helps control first-write column order in InfluxDB 3.
+ * @param precision - the writing precision
+ */
 export const writableDataToLineProtocol = (
   data: WritableData,
   defaultTags?: {[key: string]: string},

--- a/packages/client/src/util/generics.ts
+++ b/packages/client/src/util/generics.ts
@@ -48,7 +48,8 @@ export const writableDataToLineProtocol = (
     ? (arrayData as string[])
     : (arrayData as Point[])
         .map((p) => {
-          return p.getTimestamp() instanceof Date
+          return p.getTimestamp() instanceof Date ||
+            p.getTimestamp() === undefined
             ? p.toLineProtocol(precision, defaultTags, tagOrder)
             : p.toLineProtocol(undefined, defaultTags, tagOrder)
         })

--- a/packages/client/src/util/generics.ts
+++ b/packages/client/src/util/generics.ts
@@ -11,11 +11,14 @@ import {WritePrecision} from '../options'
  * - `string`: Represents lines of the [Line Protocol](https://bit.ly/2QL99fu).
  */
 export type WritableData = ArrayLike<string> | ArrayLike<Point> | string | Point
+
 /**
- * Convert `WritableData` to an array of lines of [Line Protocol](https://bit.ly/2QL99fu)).
- * If the data is an array of `Point` objects, it will be converted to lines of Line Protocol.
- * If the data is a single `Point` object, it will be converted to a single line of Line Protocol.
- * If the data is an array of lines of Line Protocol, it will be returned as is.
+ * Convert `WritableData` to an array of lines of
+ * [Line Protocol](https://bit.ly/2QL99fu)).
+ * If the data is an array of `Point` objects, it will be converted to lines of
+ * Line Protocol. If the data is a single `Point` object, it will be converted
+ * to a single line of Line Protocol. If the data is an array of lines of
+ * Line Protocol, it will be returned as is.
  *
  * @param data - data to write
  * @param defaultTags - the default tags to apply to all points.
@@ -23,7 +26,8 @@ export type WritableData = ArrayLike<string> | ArrayLike<Point> | string | Point
  * Tags listed here are written first, in the same order.
  * The remaining tags are appended in lexicographical order.
  * This helps control first-write column order in InfluxDB 3.
- * @param precision - the writing precision
+ * @param precision - the writing precision. It is used as the time precision
+ * when serializing Point instances whose timestamp is a Date
  */
 export const writableDataToLineProtocol = (
   data: WritableData,

--- a/packages/client/test/integration/e2e.test.ts
+++ b/packages/client/test/integration/e2e.test.ts
@@ -7,6 +7,7 @@ import {
   PartialWriteError,
   Point,
   PointValues,
+  WritePrecision,
 } from '../../src'
 import {rejects} from 'assert'
 import * as http from 'node:http'
@@ -660,6 +661,38 @@ describe('e2e test', () => {
         await client.close()
       }
     }).timeout(10_000)
+
+    it('successful writes when timestamp = new Date()', async () => {
+      const {database, token, url} = getEnvVariables()
+      const client = new InfluxDBClient({
+        host: url,
+        token,
+      })
+
+      const tests = [
+        {precision: 'ns'},
+        {precision: 'us'},
+        {precision: 'ms'},
+        {precision: 's'},
+      ]
+
+      for (const test of tests) {
+        try {
+          const point = Point.measurement('stat')
+            .setFloatField('avg', 1.2)
+            .setTimestamp(new Date())
+          await client.write(point, database, undefined, {
+            precision: test.precision as WritePrecision,
+          })
+          await client.write(point, database, undefined, {
+            precision: test.precision as WritePrecision,
+            useV2Api: true,
+          })
+        } catch (e: Error | any) {
+          expect.fail(e)
+        }
+      }
+    }).timeout(15_000)
   })
   describe('with node http', () => {
     const port = 65535

--- a/packages/client/test/integration/e2e.test.ts
+++ b/packages/client/test/integration/e2e.test.ts
@@ -693,6 +693,38 @@ describe('e2e test', () => {
         }
       }
     }).timeout(15_000)
+
+    it('successful writes when timestamp = undefined', async () => {
+      const {database, token, url} = getEnvVariables()
+      const client = new InfluxDBClient({
+        host: url,
+        token,
+      })
+
+      const tests = [
+        {precision: 'ns'},
+        {precision: 'us'},
+        {precision: 'ms'},
+        {precision: 's'},
+      ]
+
+      for (const test of tests) {
+        try {
+          const point = Point.measurement('stat')
+            .setFloatField('avg', 1.2)
+            .setTimestamp(undefined)
+          await client.write(point, database, undefined, {
+            precision: test.precision as WritePrecision,
+          })
+          await client.write(point, database, undefined, {
+            precision: test.precision as WritePrecision,
+            useV2Api: true,
+          })
+        } catch (e: Error | any) {
+          expect.fail(e)
+        }
+      }
+    }).timeout(15_000)
   })
   describe('with node http', () => {
     const port = 65535

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -4,13 +4,13 @@ import {
   ClientOptions,
   HttpError,
   IllegalArgumentError,
-  PartialWriteError,
-  WriteOptions,
-  Point,
   InfluxDBClient,
+  PartialWriteError,
+  Point,
+  WriteOptions,
   WritePrecision,
 } from '../../src'
-import {collectLogging, CollectedLogs, unhandledRejections} from '../util'
+import {CollectedLogs, collectLogging, unhandledRejections} from '../util'
 import zlib from 'zlib'
 import {rejects} from 'assert'
 import {isDefined} from '../../src/util/common'
@@ -88,6 +88,205 @@ describe('Write', () => {
         )
       )
     })
+    it('when timestamp == new Date(), precision == ns', async () => {
+      const tests = [
+        {
+          writePath: `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond`,
+          writeOptions: {
+            precision: 'ns',
+          },
+        },
+        {
+          writePath: `/api/v2/write?bucket=${DATABASE}&precision=ns`,
+          writeOptions: {
+            precision: 'ns',
+            useV2Api: true,
+          },
+        },
+      ]
+
+      for (const test of tests) {
+        const now = new Date()
+        nock(clientOptions.host)
+          .post(test.writePath)
+          .delay(1000)
+          .reply(function (_uri, _requestBody) {
+            if (test.writeOptions.useV2Api === true) {
+              expect(_uri.includes('precision=ns')).true
+            } else {
+              expect(_uri.includes('precision=nanosecond')).true
+            }
+
+            const time = _requestBody.split(' ')[2]
+            expect(time).equals((now.getTime() * 1_000_000).toString())
+            return [200, '', {}]
+          })
+          .persist()
+
+        const option: ClientOptions = {
+          ...clientOptions,
+          writeOptions: {
+            precision: test.writeOptions.precision as WritePrecision,
+            useV2Api: test.writeOptions.useV2Api,
+          },
+        }
+        const client: InfluxDBClient = new InfluxDBClient(option)
+        await client.write(
+          Point.measurement('test').setFloatField('value', 1).setTimestamp(now),
+          DATABASE
+        )
+      }
+    }).timeout(5000)
+
+    it('when timestamp == new Date(), precision == us', async () => {
+      const tests = [
+        {
+          writePath: `/api/v3/write_lp?db=${DATABASE}&precision=microsecond`,
+          writeOptions: {
+            precision: 'us',
+          },
+        },
+        {
+          writePath: `/api/v2/write?bucket=${DATABASE}&precision=us`,
+          writeOptions: {
+            precision: 'us',
+            useV2Api: true,
+          },
+        },
+      ]
+
+      for (const test of tests) {
+        const now = new Date()
+        nock(clientOptions.host)
+          .post(test.writePath)
+          .delay(1000)
+          .reply(function (_uri, _requestBody) {
+            if (test.writeOptions.useV2Api === true) {
+              expect(_uri.includes('precision=us')).true
+            } else {
+              expect(_uri.includes('precision=microsecond')).true
+            }
+
+            const time = _requestBody.split(' ')[2]
+            expect(time).equals((now.getTime() * 1_000).toString())
+            return [200, '', {}]
+          })
+          .persist()
+
+        const option: ClientOptions = {
+          ...clientOptions,
+          writeOptions: {
+            precision: test.writeOptions.precision as WritePrecision,
+            useV2Api: test.writeOptions.useV2Api,
+          },
+        }
+        const client: InfluxDBClient = new InfluxDBClient(option)
+        await client.write(
+          Point.measurement('test').setFloatField('value', 1).setTimestamp(now),
+          DATABASE
+        )
+      }
+    }).timeout(5000)
+
+    it('when timestamp == new Date(), precision == ms', async () => {
+      const tests = [
+        {
+          writePath: `/api/v3/write_lp?db=${DATABASE}&precision=millisecond`,
+          writeOptions: {
+            precision: 'ms',
+          },
+        },
+        {
+          writePath: `/api/v2/write?bucket=${DATABASE}&precision=ms`,
+          writeOptions: {
+            precision: 'ms',
+            useV2Api: true,
+          },
+        },
+      ]
+
+      for (const test of tests) {
+        const now = new Date()
+        nock(clientOptions.host)
+          .post(test.writePath)
+          .delay(1000)
+          .reply(function (_uri, _requestBody) {
+            if (test.writeOptions.useV2Api === true) {
+              expect(_uri.includes('precision=ms')).true
+            } else {
+              expect(_uri.includes('precision=millisecond')).true
+            }
+
+            const time = _requestBody.split(' ')[2]
+            expect(time).equals(now.getTime().toString())
+            return [200, '', {}]
+          })
+          .persist()
+
+        const option: ClientOptions = {
+          ...clientOptions,
+          writeOptions: {
+            precision: test.writeOptions.precision as WritePrecision,
+            useV2Api: test.writeOptions.useV2Api,
+          },
+        }
+        const client: InfluxDBClient = new InfluxDBClient(option)
+        await client.write(
+          Point.measurement('test').setFloatField('value', 1).setTimestamp(now),
+          DATABASE
+        )
+      }
+    }).timeout(5000)
+
+    it('when timestamp == new Date(), precision == s', async () => {
+      const tests = [
+        {
+          writePath: `/api/v3/write_lp?db=${DATABASE}&precision=second`,
+          writeOptions: {
+            precision: 's',
+          },
+        },
+        {
+          writePath: `/api/v2/write?bucket=${DATABASE}&precision=s`,
+          writeOptions: {
+            precision: 's',
+            useV2Api: true,
+          },
+        },
+      ]
+
+      for (const test of tests) {
+        const now = new Date()
+        nock(clientOptions.host)
+          .post(test.writePath)
+          .delay(1000)
+          .reply(function (_uri, _requestBody) {
+            if (test.writeOptions.useV2Api === true) {
+              expect(_uri.includes('precision=s')).true
+            } else {
+              expect(_uri.includes('precision=second')).true
+            }
+
+            const time = _requestBody.split(' ')[2]
+            expect(time).equals(Math.floor(now.getTime() / 1000).toString())
+            return [200, '', {}]
+          })
+          .persist()
+
+        const option: ClientOptions = {
+          ...clientOptions,
+          writeOptions: {
+            precision: test.writeOptions.precision as WritePrecision,
+            useV2Api: test.writeOptions.useV2Api,
+          },
+        }
+        const client: InfluxDBClient = new InfluxDBClient(option)
+        await client.write(
+          Point.measurement('test').setFloatField('value', 1).setTimestamp(now),
+          DATABASE
+        )
+      }
+    }).timeout(5000)
   })
 
   describe('usage of server API', () => {

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -151,7 +151,6 @@ describe('Write', () => {
           const now = new Date()
           nock(clientOptions.host)
             .post(test.writePath)
-            .delay(1000)
             .reply(function (_uri, _requestBody) {
               expect(_uri.includes(`precision=${test.expectedPrecisionParam}`))
                 .true

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -88,205 +88,95 @@ describe('Write', () => {
         )
       )
     })
-    it('when timestamp == new Date(), precision == ns', async () => {
-      const tests = [
+
+    it('when timestamp == new Date()', async () => {
+      const timestampPrecisionCases: Array<{
+        precision: WritePrecision
+        v3PrecisionParam: string
+        v2PrecisionParam: string
+        expectedTimestamp: (date: Date) => string
+      }> = [
         {
-          writePath: `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond`,
-          writeOptions: {
-            precision: 'ns',
-          },
+          precision: 'ns',
+          v3PrecisionParam: 'nanosecond',
+          v2PrecisionParam: 'ns',
+          expectedTimestamp: (date: Date) => `${date.getTime()}000000`,
         },
         {
-          writePath: `/api/v2/write?bucket=${DATABASE}&precision=ns`,
-          writeOptions: {
-            precision: 'ns',
-            useV2Api: true,
-          },
-        },
-      ]
-
-      for (const test of tests) {
-        const now = new Date()
-        nock(clientOptions.host)
-          .post(test.writePath)
-          .delay(1000)
-          .reply(function (_uri, _requestBody) {
-            if (test.writeOptions.useV2Api === true) {
-              expect(_uri.includes('precision=ns')).true
-            } else {
-              expect(_uri.includes('precision=nanosecond')).true
-            }
-
-            const time = _requestBody.split(' ')[2]
-            expect(time).equals((now.getTime() * 1_000_000).toString())
-            return [200, '', {}]
-          })
-          .persist()
-
-        const option: ClientOptions = {
-          ...clientOptions,
-          writeOptions: {
-            precision: test.writeOptions.precision as WritePrecision,
-            useV2Api: test.writeOptions.useV2Api,
-          },
-        }
-        const client: InfluxDBClient = new InfluxDBClient(option)
-        await client.write(
-          Point.measurement('test').setFloatField('value', 1).setTimestamp(now),
-          DATABASE
-        )
-      }
-    }).timeout(5000)
-
-    it('when timestamp == new Date(), precision == us', async () => {
-      const tests = [
-        {
-          writePath: `/api/v3/write_lp?db=${DATABASE}&precision=microsecond`,
-          writeOptions: {
-            precision: 'us',
-          },
+          precision: 'us',
+          v3PrecisionParam: 'microsecond',
+          v2PrecisionParam: 'us',
+          expectedTimestamp: (date: Date) => `${date.getTime()}000`,
         },
         {
-          writePath: `/api/v2/write?bucket=${DATABASE}&precision=us`,
-          writeOptions: {
-            precision: 'us',
-            useV2Api: true,
-          },
+          precision: 'ms',
+          v3PrecisionParam: 'millisecond',
+          v2PrecisionParam: 'ms',
+          expectedTimestamp: (date: Date) => date.getTime().toString(),
+        },
+        {
+          precision: 's',
+          v3PrecisionParam: 'second',
+          v2PrecisionParam: 's',
+          expectedTimestamp: (date: Date) =>
+            Math.floor(date.getTime() / 1000).toString(),
         },
       ]
 
-      for (const test of tests) {
-        const now = new Date()
-        nock(clientOptions.host)
-          .post(test.writePath)
-          .delay(1000)
-          .reply(function (_uri, _requestBody) {
-            if (test.writeOptions.useV2Api === true) {
-              expect(_uri.includes('precision=us')).true
-            } else {
-              expect(_uri.includes('precision=microsecond')).true
-            }
-
-            const time = _requestBody.split(' ')[2]
-            expect(time).equals((now.getTime() * 1_000).toString())
-            return [200, '', {}]
-          })
-          .persist()
-
-        const option: ClientOptions = {
-          ...clientOptions,
-          writeOptions: {
-            precision: test.writeOptions.precision as WritePrecision,
-            useV2Api: test.writeOptions.useV2Api,
+      for (const {
+        precision,
+        v3PrecisionParam,
+        v2PrecisionParam,
+        expectedTimestamp,
+      } of timestampPrecisionCases) {
+        const tests = [
+          {
+            writePath: `/api/v3/write_lp?db=${DATABASE}&precision=${v3PrecisionParam}`,
+            expectedPrecisionParam: v3PrecisionParam,
+            writeOptions: {
+              precision,
+            },
           },
+          {
+            writePath: `/api/v2/write?bucket=${DATABASE}&precision=${v2PrecisionParam}`,
+            expectedPrecisionParam: v2PrecisionParam,
+            writeOptions: {
+              precision,
+              useV2Api: true,
+            },
+          },
+        ]
+
+        for (const test of tests) {
+          const now = new Date()
+          nock(clientOptions.host)
+            .post(test.writePath)
+            .delay(1000)
+            .reply(function (_uri, _requestBody) {
+              expect(_uri.includes(`precision=${test.expectedPrecisionParam}`))
+                .true
+              const time = _requestBody.split(' ')[2]
+              expect(time).equals(expectedTimestamp(now))
+              return [200, '', {}]
+            })
+            .persist()
+          const option: ClientOptions = {
+            ...clientOptions,
+            writeOptions: {
+              precision: test.writeOptions.precision,
+              useV2Api: test.writeOptions.useV2Api,
+            },
+          }
+          const client: InfluxDBClient = new InfluxDBClient(option)
+          await client.write(
+            Point.measurement('test')
+              .setFloatField('value', 1)
+              .setTimestamp(now),
+            DATABASE
+          )
         }
-        const client: InfluxDBClient = new InfluxDBClient(option)
-        await client.write(
-          Point.measurement('test').setFloatField('value', 1).setTimestamp(now),
-          DATABASE
-        )
       }
-    }).timeout(5000)
-
-    it('when timestamp == new Date(), precision == ms', async () => {
-      const tests = [
-        {
-          writePath: `/api/v3/write_lp?db=${DATABASE}&precision=millisecond`,
-          writeOptions: {
-            precision: 'ms',
-          },
-        },
-        {
-          writePath: `/api/v2/write?bucket=${DATABASE}&precision=ms`,
-          writeOptions: {
-            precision: 'ms',
-            useV2Api: true,
-          },
-        },
-      ]
-
-      for (const test of tests) {
-        const now = new Date()
-        nock(clientOptions.host)
-          .post(test.writePath)
-          .delay(1000)
-          .reply(function (_uri, _requestBody) {
-            if (test.writeOptions.useV2Api === true) {
-              expect(_uri.includes('precision=ms')).true
-            } else {
-              expect(_uri.includes('precision=millisecond')).true
-            }
-
-            const time = _requestBody.split(' ')[2]
-            expect(time).equals(now.getTime().toString())
-            return [200, '', {}]
-          })
-          .persist()
-
-        const option: ClientOptions = {
-          ...clientOptions,
-          writeOptions: {
-            precision: test.writeOptions.precision as WritePrecision,
-            useV2Api: test.writeOptions.useV2Api,
-          },
-        }
-        const client: InfluxDBClient = new InfluxDBClient(option)
-        await client.write(
-          Point.measurement('test').setFloatField('value', 1).setTimestamp(now),
-          DATABASE
-        )
-      }
-    }).timeout(5000)
-
-    it('when timestamp == new Date(), precision == s', async () => {
-      const tests = [
-        {
-          writePath: `/api/v3/write_lp?db=${DATABASE}&precision=second`,
-          writeOptions: {
-            precision: 's',
-          },
-        },
-        {
-          writePath: `/api/v2/write?bucket=${DATABASE}&precision=s`,
-          writeOptions: {
-            precision: 's',
-            useV2Api: true,
-          },
-        },
-      ]
-
-      for (const test of tests) {
-        const now = new Date()
-        nock(clientOptions.host)
-          .post(test.writePath)
-          .delay(1000)
-          .reply(function (_uri, _requestBody) {
-            if (test.writeOptions.useV2Api === true) {
-              expect(_uri.includes('precision=s')).true
-            } else {
-              expect(_uri.includes('precision=second')).true
-            }
-
-            const time = _requestBody.split(' ')[2]
-            expect(time).equals(Math.floor(now.getTime() / 1000).toString())
-            return [200, '', {}]
-          })
-          .persist()
-
-        const option: ClientOptions = {
-          ...clientOptions,
-          writeOptions: {
-            precision: test.writeOptions.precision as WritePrecision,
-            useV2Api: test.writeOptions.useV2Api,
-          },
-        }
-        const client: InfluxDBClient = new InfluxDBClient(option)
-        await client.write(
-          Point.measurement('test').setFloatField('value', 1).setTimestamp(now),
-          DATABASE
-        )
-      }
-    }).timeout(5000)
+    }).timeout(20000)
   })
 
   describe('usage of server API', () => {

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -149,13 +149,13 @@ describe('Write', () => {
 
         for (const test of tests) {
           const now = new Date()
+          let uri = ''
+          let timestamp = ''
           nock(clientOptions.host)
             .post(test.writePath)
             .reply(function (_uri, _requestBody) {
-              expect(_uri.includes(`precision=${test.expectedPrecisionParam}`))
-                .true
-              const time = _requestBody.split(' ')[2]
-              expect(time).equals(expectedTimestamp(now))
+              uri = _uri
+              timestamp = _requestBody.split(' ')[2]
               return [200, '', {}]
             })
             .persist()
@@ -173,6 +173,9 @@ describe('Write', () => {
               .setTimestamp(now),
             DATABASE
           )
+
+          expect(uri.includes(`precision=${test.expectedPrecisionParam}`)).true
+          expect(timestamp).equals(expectedTimestamp(now))
         }
       }
     }).timeout(20000)


### PR DESCRIPTION
Closes #

## Proposed Changes

- When setting Point timestamp to `new Date()`, the timestamp sent to the servers will be converted to `precision` set in `WriteOptions`.
- Add more tests for these new changes.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
