### PR TITLE
fix: partial write support and default write endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 ## 2.3.0 [unreleased]
 
-### Breaking Changes
-
-1. [#773](https://github.com/InfluxCommunity/influxdb3-js/pull/773): Adds partial write support and aligns write routing with v3 defaults.
-   See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
-   For InfluxDB Clustered, set `useV2Api: true` for writes.
-
 ### Features
 
 1. [#790](https://github.com/InfluxCommunity/influxdb3-js/pull/790): When setting Point timestamp to `new Date()`, the timestamp sent to the servers will be converted to the precision set in `WriteOptions`.
+2. [#796](https://github.com/InfluxCommunity/influxdb3-js/pull/796): Adds partial write support and API endpoint selection for writes.
+   - Writes use the V2 API endpoint by default.
+   - `noSync` requires the V3 API endpoint; `acceptPartial` applies only to the V3 API endpoint and is ignored when using the V2 API endpoint.
+   - See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -165,21 +165,46 @@ Partial writes are enabled by default.
 Configure `acceptPartial` using client `writeOptions`, per-write options, or
 connection/env (`writeAcceptPartial`, `INFLUX_WRITE_ACCEPT_PARTIAL`).
 
-When only part of a v3 write request is rejected, the client throws
+When only part of a V3 write request is rejected, the client throws
 `PartialWriteError` with structured `lineErrors`.
 If partial writes are disabled (`acceptPartial: false`), a rejected line causes
 the whole batch to be rejected.
 
-#### Compatibility with InfluxDB Clustered
+To inspect line-level failures, write through the V3 API endpoint and catch
+`PartialWriteError`:
 
-Set `useV2Api: true` to write through the v2 compatibility endpoint.
-You can set it in client `writeOptions`, per-write options, or via
+```ts
+const lp = [
+  'home,room=Sunroom temp=96 1735545600',
+  'home,room=Sunroom temp="hi" 1735549200',
+].join('\n')
+
+try {
+  await client.write(lp, database, undefined, {
+    useV2Api: false,
+  })
+} catch (e: any) {
+  if (e instanceof PartialWriteError) {
+    for (const lineErr of e.lineErrors) {
+      console.log(`line ${lineErr.lineNumber}: ${lineErr.errorMessage} (${lineErr.originalLine})`)
+    }
+  }
+}
+```
+
+#### Compatibility with InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless
+
+Writes use the V2 API endpoint by default.
+You can set `useV2Api` in client `writeOptions`, per-write options, or via
 connection/env (`writeUseV2Api`, `INFLUX_WRITE_USE_V2_API`).
 
-With `useV2Api`, `acceptPartial` is ignored and rejected writes return flat v2
-errors. `noSync` cannot be used with `useV2Api`; this combination is rejected
-before request dispatch with:
-`invalid write options: noSync cannot be used with useV2Api`.
+Set `useV2Api: false` to write through the V3 API endpoint (InfluxDB 3 Core/Enterprise),
+which supports `noSync` and `acceptPartial` controls.
+
+When writing through the V2 API endpoint, `acceptPartial` is not used by the client.
+Rejected writes return flat V2 errors.
+`noSync` cannot be used with `useV2Api`; this combination is rejected before request
+dispatch with `invalid write options: noSync requires useV2Api=false`.
 
 ### Query data
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ await client.write(point, database, undefined, {
 
 #### Accept partial writes and inspect failed lines
 
-Partial writes are enabled by default.
+Partial writes are enabled by default when writing through the V3 API endpoint (`useV2Api=false`).
 Configure `acceptPartial` using client `writeOptions`, per-write options, or
 connection/env (`writeAcceptPartial`, `INFLUX_WRITE_ACCEPT_PARTIAL`).
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ set INFLUX_TOKEN=<token>
 To get started with influxdb client import `@influxdata/influxdb3-client` package.
 
 ```ts
-import {InfluxDBClient, Point} from '@influxdata/influxdb3-client'
+import {InfluxDBClient, PartialWriteError, Point} from '@influxdata/influxdb3-client'
 ```
 
 Assign values for environment variables, and then instantiate `InfluxDBClient` inside of an asynchronous function.

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -52,7 +52,7 @@ export default class InfluxDBClient {
    *   - gzipThreshold - payload size threshold for gzipping data
    *   - writeAcceptPartial - allow partial writes when some lines fail
    *   - writeNoSync - skip waiting for WAL persistence on write
-   *   - writeUseV2Api - use /api/v2/write compatibility endpoint
+   *   - writeUseV2Api - use /api/v2/write V2 API endpoint
    *
    * @param connectionString - connection string
    */
@@ -71,7 +71,7 @@ export default class InfluxDBClient {
    *   - INFLUX_GZIP_THRESHOLD - payload size threshold for gzipping data
    *   - INFLUX_WRITE_ACCEPT_PARTIAL - allow partial writes when some lines fail
    *   - INFLUX_WRITE_NO_SYNC - skip waiting for WAL persistence on write
-   *   - INFLUX_WRITE_USE_V2_API - use /api/v2/write compatibility endpoint
+   *   - INFLUX_WRITE_USE_V2_API - use /api/v2/write V2 API endpoint
    *   - INFLUX_GRPC_OPTIONS - comma separated set of key=value pairs matching @grpc/grpc-js channel options.
    */
   constructor()

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -37,7 +37,9 @@ function parseOriginalLine(value: unknown): string {
   throw new Error('original_line must be string')
 }
 
-function parsePartialWriteDataItem(item: unknown): PartialWriteLineError | null {
+function parsePartialWriteDataItem(
+  item: unknown
+): PartialWriteLineError | null {
   if (item === undefined || item === null) {
     return null
   }
@@ -51,7 +53,9 @@ function parsePartialWriteDataItem(item: unknown): PartialWriteLineError | null 
   if (errorMessage.length === 0) {
     return null
   }
-  const lineNumber = parseLineNumber((item as {line_number?: unknown}).line_number)
+  const lineNumber = parseLineNumber(
+    (item as {line_number?: unknown}).line_number
+  )
   const originalLine = parseOriginalLine(
     (item as {original_line?: unknown}).original_line
   )
@@ -99,7 +103,9 @@ function formatTypedLineErrorDetails(
           `\tline ${lineError.lineNumber}: ${lineError.errorMessage} (${lineError.originalLine})`
         )
       } else {
-        details.push(`\tline ${lineError.lineNumber}: ${lineError.errorMessage}`)
+        details.push(
+          `\tline ${lineError.lineNumber}: ${lineError.errorMessage}`
+        )
       }
     } else {
       details.push(`\t${lineError.errorMessage}`)

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -17,23 +17,44 @@ function isV3PartialWriteErrorMessage(errorMessage: unknown): boolean {
   )
 }
 
-function toLineError(item: unknown): PartialWriteLineError | undefined {
-  if (!item || typeof item !== 'object' || Array.isArray(item)) {
-    return undefined
+function parseLineNumber(value: unknown): number {
+  if (value === undefined || value === null) {
+    return 0
   }
-  const lineNumber = (item as {line_number?: unknown}).line_number
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  throw new Error('line_number must be number')
+}
+
+function parseOriginalLine(value: unknown): string {
+  if (value === undefined || value === null) {
+    return ''
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  throw new Error('original_line must be string')
+}
+
+function parsePartialWriteDataItem(item: unknown): PartialWriteLineError | null {
+  if (item === undefined || item === null) {
+    return null
+  }
+  if (typeof item !== 'object' || Array.isArray(item)) {
+    throw new Error('item is not an object')
+  }
   const errorMessage = (item as {error_message?: unknown}).error_message
-  const originalLine = (item as {original_line?: unknown}).original_line
-  if (
-    typeof lineNumber !== 'number' ||
-    !Number.isFinite(lineNumber) ||
-    typeof errorMessage !== 'string' ||
-    errorMessage.length === 0 ||
-    typeof originalLine !== 'string' ||
-    originalLine.length === 0
-  ) {
-    return undefined
+  if (typeof errorMessage !== 'string') {
+    throw new Error('error_message must be string')
   }
+  if (errorMessage.length === 0) {
+    return null
+  }
+  const lineNumber = parseLineNumber((item as {line_number?: unknown}).line_number)
+  const originalLine = parseOriginalLine(
+    (item as {original_line?: unknown}).original_line
+  )
   return {lineNumber, errorMessage, originalLine}
 }
 
@@ -44,12 +65,15 @@ function parseTypedLineErrors(
     return undefined
   }
   const lineErrors: PartialWriteLineError[] = []
-  for (const item of data) {
-    const lineError = toLineError(item)
-    if (!lineError) {
-      return undefined
+  try {
+    for (const item of data) {
+      const lineError = parsePartialWriteDataItem(item)
+      if (lineError) {
+        lineErrors.push(lineError)
+      }
     }
-    lineErrors.push(lineError)
+  } catch {
+    return undefined
   }
   return lineErrors.length > 0 ? lineErrors : undefined
 }
@@ -57,7 +81,31 @@ function parseTypedLineErrors(
 function parseSingleLineError(
   data: unknown
 ): PartialWriteLineError | undefined {
-  return toLineError(data)
+  try {
+    return parsePartialWriteDataItem(data) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+function formatTypedLineErrorDetails(
+  lineErrors: PartialWriteLineError[]
+): string[] {
+  const details: string[] = []
+  for (const lineError of lineErrors) {
+    if (lineError.lineNumber !== 0) {
+      if (lineError.originalLine.length > 0) {
+        details.push(
+          `\tline ${lineError.lineNumber}: ${lineError.errorMessage} (${lineError.originalLine})`
+        )
+      } else {
+        details.push(`\tline ${lineError.lineNumber}: ${lineError.errorMessage}`)
+      }
+    } else {
+      details.push(`\t${lineError.errorMessage}`)
+    }
+  }
+  return details
 }
 
 function formatErrorMessage(node: any): string | undefined {
@@ -71,55 +119,31 @@ function formatErrorMessage(node: any): string | undefined {
 
   const errorText = typeof node.error === 'string' ? node.error : undefined
   const data = node.data
-  if (
-    errorText &&
-    isV3PartialWriteErrorMessage(errorText) &&
-    Array.isArray(data)
-  ) {
-    const details: string[] = []
-    for (const item of data) {
-      if (item === undefined || item === null) {
-        continue
-      }
-      if (typeof item === 'string' && item.length > 0) {
-        details.push(`\t${item}`)
-        continue
-      }
-      if (!item || typeof item !== 'object' || Array.isArray(item)) {
-        details.push(`\t${String(item)}`)
-        continue
-      }
-      const lineNumber = item.line_number
-      const errorMessage = item.error_message
-      const originalLine = item.original_line
-      if (
-        lineNumber !== undefined &&
-        lineNumber !== null &&
-        typeof errorMessage === 'string' &&
-        errorMessage.length > 0 &&
-        typeof originalLine === 'string' &&
-        originalLine.length > 0
-      ) {
-        details.push(`\tline ${lineNumber}: ${errorMessage} (${originalLine})`)
-      } else if (typeof errorMessage === 'string' && errorMessage.length > 0) {
-        details.push(`\t${errorMessage}`)
-      }
-    }
-    if (details.length) {
+  if (errorText && isV3PartialWriteErrorMessage(errorText)) {
+    const typedArray = parseTypedLineErrors(data)
+    if (typedArray) {
+      const details = formatTypedLineErrorDetails(typedArray)
       return `${errorText}:\n${details.join('\n')}`
     }
-    return errorText
-  }
-  if (
-    errorText &&
-    isV3PartialWriteErrorMessage(errorText) &&
-    data &&
-    typeof data === 'object' &&
-    !Array.isArray(data)
-  ) {
-    const errorMessage = (data as {error_message?: unknown}).error_message
-    if (typeof errorMessage === 'string' && errorMessage.length > 0) {
-      return `${errorText}:\n\t${errorMessage}`
+    if (Array.isArray(data)) {
+      const details: string[] = []
+      for (const item of data) {
+        if (item == null) {
+          continue
+        }
+        const raw = JSON.stringify(item)
+        if (raw && raw.toLowerCase() !== 'null') {
+          details.push(`\t${raw}`)
+        }
+      }
+      if (details.length) {
+        return `${errorText}:\n${details.join('\n')}`
+      }
+      return errorText
+    }
+    const single = parseSingleLineError(data)
+    if (single) {
+      return `${errorText}:\n${formatTypedLineErrorDetails([single]).join('\n')}`
     }
     return errorText
   }

--- a/packages/client/src/impl/WriteApiImpl.ts
+++ b/packages/client/src/impl/WriteApiImpl.ts
@@ -72,7 +72,7 @@ export default class WriteApiImpl implements WriteApi {
     if (writeOptionsOrDefault.useV2Api && writeOptionsOrDefault.noSync) {
       return Promise.reject(
         new IllegalArgumentError(
-          'invalid write options: noSync cannot be used with useV2Api'
+          'invalid write options: noSync requires useV2Api=false'
         )
       )
     }
@@ -109,9 +109,15 @@ export default class WriteApiImpl implements WriteApi {
         }
         if (error instanceof HttpError) {
           const statusCode = responseStatusCode ?? error.statusCode
+          if (statusCode === 405 && writeOptionsOrDefault.useV2Api) {
+            error.message =
+              "Server doesn't support the V2 API endpoint (/api/v2/write). " +
+              'Set useV2Api=false to use the V3 API endpoint.'
+          }
           if (statusCode === 405 && !writeOptionsOrDefault.useV2Api) {
             error.message =
-              "Server doesn't support v3 write API. Set useV2Api=true for v2 compatibility endpoint."
+              "Server doesn't support the V3 API endpoint (/api/v3/write_lp). " +
+              'Set useV2Api=true to use the V2 API endpoint.'
           }
           const partialWriteError = PartialWriteError.fromHttpError(error)
           if (partialWriteError) {

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -102,25 +102,27 @@ export interface WriteOptions {
    * noSync=true means faster write but without the confirmation that the data was persisted.
    *
    * Note: This option is supported by InfluxDB 3 Core and Enterprise servers only.
-   * For other InfluxDB 3 server types (InfluxDB Clustered, InfluxDB Clould Serverless/Dedicated)
+   * For other InfluxDB 3 server types (InfluxDB Clustered, InfluxDB Cloud Dedicated/Serverless)
    * the write operation will fail with an error.
    *
    * Default value: false.
    */
   noSync?: boolean
   /**
-   * Allow partial success when some lines in a write batch are rejected.
+   * Controls partial-write behavior for writes sent to the V3 API endpoint
+   * (useV2Api=false).
+   * The client sends accept_partial=false only when set to false.
    *
+   * For writes sent to the V2 API endpoint (useV2Api=true), this option is not used.
    * Default value: true.
    */
   acceptPartial?: boolean
   /**
-   * Use the v2 compatibility write endpoint.
+   * Forces writes to the V2 API endpoint.
+   * Use this for InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless.
+   * For InfluxDB 3 Core/Enterprise, set useV2Api=false to write through the V3 API endpoint.
    *
-   * This is intended for InfluxDB Clustered compatibility mode.
-   * When enabled, writes use /api/v2/write and ignore acceptPartial.
-   *
-   * Default value: false.
+   * Default value: true.
    */
   useV2Api?: boolean
   /** default tags
@@ -177,7 +179,7 @@ export const DEFAULT_WriteOptions: WriteOptions = {
   gzipThreshold: 1000,
   noSync: false,
   acceptPartial: true,
-  useV2Api: false,
+  useV2Api: true,
 }
 
 export type QueryType = 'sql' | 'influxql'

--- a/packages/client/test/integration/e2e.test.ts
+++ b/packages/client/test/integration/e2e.test.ts
@@ -580,7 +580,7 @@ describe('e2e test', () => {
       expect(count).to.be.greaterThan(0)
     }).timeout(7_000)
 
-    it('reports partial write details when acceptPartial=true (default)', async () => {
+    it('reports partial write details when useV2Api=false and acceptPartial=true', async () => {
       const {database, token, url} = getEnvVariables()
       const client = new InfluxDBClient({
         host: url,
@@ -594,7 +594,7 @@ describe('e2e test', () => {
       ].join('\n')
 
       try {
-        await client.write(lp, database)
+        await client.write(lp, database, undefined, {useV2Api: false})
         expect.fail('failure expected')
       } catch (e: any) {
         expect(e).instanceOf(PartialWriteError)
@@ -622,6 +622,7 @@ describe('e2e test', () => {
 
       try {
         await client.write(lp, database, undefined, {
+          useV2Api: false,
           acceptPartial: false,
         })
         expect.fail('failure expected')
@@ -635,7 +636,7 @@ describe('e2e test', () => {
       }
     }).timeout(10_000)
 
-    it('uses v2 compatibility endpoint and returns non-structured error', async () => {
+    it('uses V2 API endpoint and returns non-structured error', async () => {
       const {database, token, url} = getEnvVariables()
       const client = new InfluxDBClient({
         host: url,

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -877,7 +877,7 @@ at 'ClientOptions.database'
       let special: any
       let oneOff: any
       nock('http://test:8086')
-        .post(`/api/v3/write_lp?db=${DATABASE}&precision=nanosecond`)
+        .post(`/api/v2/write?bucket=${DATABASE}&precision=ns`)
         .reply(
           204,
           function (_uri, _body, callback) {

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -606,7 +606,10 @@ describe('Write', () => {
       useSubject({
         useV2Api: true,
       })
-      nock(clientOptions.host).post(WRITE_PATH_NS_V2).reply(405, '', {}).persist()
+      nock(clientOptions.host)
+        .post(WRITE_PATH_NS_V2)
+        .reply(405, '', {})
+        .persist()
 
       await subject.write('test value=1', DATABASE).catch((e) => {
         expect(e).instanceOf(HttpError)

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -22,10 +22,10 @@ const clientOptions: ClientOptions = {
 const DATABASE = 'database'
 const PRECISION: WritePrecision = 's'
 
-const WRITE_PATH_NS = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond`
+const WRITE_PATH_NS = `/api/v2/write?bucket=${DATABASE}&precision=ns`
+const WRITE_PATH_NS_V3 = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond`
 const WRITE_PATH_NS_V3_NO_SYNC = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond&no_sync=true`
 const WRITE_PATH_NS_V3_ACCEPT_PARTIAL_FALSE = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond&accept_partial=false`
-const WRITE_PATH_NS_V2 = `/api/v2/write?bucket=${DATABASE}&precision=ns`
 
 function createApi(options: Partial<WriteOptions>): InfluxDBClient {
   return new InfluxDBClient({
@@ -135,6 +135,7 @@ describe('Write', () => {
             expectedPrecisionParam: v3PrecisionParam,
             writeOptions: {
               precision,
+              useV2Api: false,
             },
           },
           {
@@ -421,29 +422,29 @@ describe('Write', () => {
     })
     ;[
       {
-        title: 'calls v3 api by default',
+        title: 'calls v2 api by default',
         writeOptions: {},
         path: WRITE_PATH_NS,
       },
       {
-        title: 'calls v3 api if noSync=false',
-        writeOptions: {noSync: false},
-        path: WRITE_PATH_NS,
+        title: 'calls v3 api if useV2Api=false',
+        writeOptions: {useV2Api: false},
+        path: WRITE_PATH_NS_V3,
       },
       {
         title: 'calls v3 api if noSync=true',
-        writeOptions: {noSync: true},
+        writeOptions: {useV2Api: false, noSync: true},
         path: WRITE_PATH_NS_V3_NO_SYNC,
       },
       {
         title: 'calls v3 api with accept_partial=false',
-        writeOptions: {acceptPartial: false},
+        writeOptions: {useV2Api: false, acceptPartial: false},
         path: WRITE_PATH_NS_V3_ACCEPT_PARTIAL_FALSE,
       },
       {
         title: 'calls v2 api if useV2Api=true',
         writeOptions: {useV2Api: true},
-        path: WRITE_PATH_NS_V2,
+        path: WRITE_PATH_NS,
       },
     ].forEach(({title, writeOptions, path}) => {
       it(title, async () => {
@@ -481,7 +482,7 @@ describe('Write', () => {
           .catch((e) => {
             expect(e).instanceOf(IllegalArgumentError)
             expect(e.message).equals(
-              'invalid write options: noSync cannot be used with useV2Api'
+              'invalid write options: noSync requires useV2Api=false'
             )
           })
       }
@@ -491,9 +492,11 @@ describe('Write', () => {
     })
 
     it('returns PartialWriteError for v3 partial write data array', async () => {
-      useSubject({})
+      useSubject({
+        useV2Api: false,
+      })
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V3)
         .reply(function (_uri) {
           return [
             400,
@@ -533,6 +536,7 @@ describe('Write', () => {
 
     it('returns PartialWriteError for v3 write_lp parsing failed object data', async () => {
       useSubject({
+        useV2Api: false,
         acceptPartial: false,
       })
       nock(clientOptions.host)
@@ -572,7 +576,7 @@ describe('Write', () => {
         useV2Api: true,
       })
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS_V2)
+        .post(WRITE_PATH_NS)
         .reply(function (_uri) {
           return [
             400,
@@ -596,6 +600,37 @@ describe('Write', () => {
       expect(logs.error).to.length(1)
       expect(logs.warn).to.length(0)
       expect(nock.isDone()).to.be.true
+    })
+
+    it('returns endpoint guidance for useV2Api=true on v3-only backend', async () => {
+      useSubject({
+        useV2Api: true,
+      })
+      nock(clientOptions.host).post(WRITE_PATH_NS).reply(405, '', {}).persist()
+
+      await subject.write('test value=1', DATABASE).catch((e) => {
+        expect(e).instanceOf(HttpError)
+        expect(e.message).equals(
+          "Server doesn't support the V2 API endpoint (/api/v2/write). Set useV2Api=false to use the V3 API endpoint."
+        )
+      })
+    })
+
+    it('returns endpoint guidance for useV2Api=false on v2-only backend', async () => {
+      useSubject({
+        useV2Api: false,
+      })
+      nock(clientOptions.host)
+        .post(WRITE_PATH_NS_V3)
+        .reply(405, '', {})
+        .persist()
+
+      await subject.write('test value=1', DATABASE).catch((e) => {
+        expect(e).instanceOf(HttpError)
+        expect(e.message).equals(
+          "Server doesn't support the V3 API endpoint (/api/v3/write_lp). Set useV2Api=true to use the V2 API endpoint."
+        )
+      })
     })
   })
   describe('propagate error headers', async () => {

--- a/packages/client/test/unit/Write.test.ts
+++ b/packages/client/test/unit/Write.test.ts
@@ -22,7 +22,7 @@ const clientOptions: ClientOptions = {
 const DATABASE = 'database'
 const PRECISION: WritePrecision = 's'
 
-const WRITE_PATH_NS = `/api/v2/write?bucket=${DATABASE}&precision=ns`
+const WRITE_PATH_NS_V2 = `/api/v2/write?bucket=${DATABASE}&precision=ns`
 const WRITE_PATH_NS_V3 = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond`
 const WRITE_PATH_NS_V3_NO_SYNC = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond&no_sync=true`
 const WRITE_PATH_NS_V3_ACCEPT_PARTIAL_FALSE = `/api/v3/write_lp?db=${DATABASE}&precision=nanosecond&accept_partial=false`
@@ -219,7 +219,7 @@ describe('Write', () => {
           let failNextRequest = false
           const messages: string[] = []
           nock(clientOptions.host)
-            .post(WRITE_PATH_NS)
+            .post(WRITE_PATH_NS_V2)
             .reply(function (_uri, requestBody) {
               requests++
               if (failNextRequest) {
@@ -306,7 +306,7 @@ describe('Write', () => {
       })
       const messages: string[] = []
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .reply(function (_uri, requestBody) {
           messages.push(requestBody.toString())
           return [204, '', {}]
@@ -330,7 +330,7 @@ describe('Write', () => {
       useSubject({})
       let authorization: any
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .reply(function (_uri, _requestBody) {
           authorization = this.req.headers.authorization
           return [500, '', {}]
@@ -352,7 +352,7 @@ describe('Write', () => {
       useSubject({})
       let authorization: any
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .reply(function (_uri, _requestBody) {
           authorization = this.req.headers.authorization
           return [201, '', {}]
@@ -373,7 +373,7 @@ describe('Write', () => {
       let authorization: any
       let channelLane = ''
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .reply(function (_uri, _requestBody) {
           authorization = this.req.headers.authorization
           channelLane = this.req.headers['channel-lane']
@@ -404,7 +404,7 @@ describe('Write', () => {
       let universal: any
       let particular: any
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .reply(function (_uri, _requestBody) {
           universal = this.req.headers.universal
           particular = this.req.headers.particular
@@ -424,7 +424,7 @@ describe('Write', () => {
       {
         title: 'calls v2 api by default',
         writeOptions: {},
-        path: WRITE_PATH_NS,
+        path: WRITE_PATH_NS_V2,
       },
       {
         title: 'calls v3 api if useV2Api=false',
@@ -444,7 +444,7 @@ describe('Write', () => {
       {
         title: 'calls v2 api if useV2Api=true',
         writeOptions: {useV2Api: true},
-        path: WRITE_PATH_NS,
+        path: WRITE_PATH_NS_V2,
       },
     ].forEach(({title, writeOptions, path}) => {
       it(title, async () => {
@@ -576,7 +576,7 @@ describe('Write', () => {
         useV2Api: true,
       })
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .reply(function (_uri) {
           return [
             400,
@@ -606,7 +606,7 @@ describe('Write', () => {
       useSubject({
         useV2Api: true,
       })
-      nock(clientOptions.host).post(WRITE_PATH_NS).reply(405, '', {}).persist()
+      nock(clientOptions.host).post(WRITE_PATH_NS_V2).reply(405, '', {}).persist()
 
       await subject.write('test value=1', DATABASE).catch((e) => {
         expect(e).instanceOf(HttpError)
@@ -639,7 +639,7 @@ describe('Write', () => {
         ...clientOptions,
       })
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .reply(function (_uri, _requestBody) {
           return [
             429,
@@ -669,7 +669,7 @@ describe('Write', () => {
       })
       const retryDate = new Date(new Date().valueOf() + 600000)
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .reply(function (_uri, _requestBody) {
           return [
             503,
@@ -699,7 +699,7 @@ describe('Write', () => {
 
     it('timeout when passing timeout directly to write function will have the highest priority', async function () {
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .delay(1000)
         .reply(function (_uri, _requestBody) {
           return [200, '', {}]
@@ -729,7 +729,7 @@ describe('Write', () => {
 
     it('timeout by timeout property in ClientOptions', async function () {
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .delay(1000)
         .reply(function (_uri, _requestBody) {
           return [200, '', {}]
@@ -753,7 +753,7 @@ describe('Write', () => {
 
     it('WriteOptions.timeout > legacy timeout and new property writeTimeout', async function () {
       nock(clientOptions.host)
-        .post(WRITE_PATH_NS)
+        .post(WRITE_PATH_NS_V2)
         .delay(1000)
         .reply(function (_uri, _requestBody) {
           return [200, '', {}]

--- a/packages/client/test/unit/errors.test.ts
+++ b/packages/client/test/unit/errors.test.ts
@@ -104,7 +104,7 @@ describe('errors', () => {
         data: [{line_number: 2}],
       })
       expect(new HttpError(400, 'Bad Request', body).message).equals(
-        'partial write of line protocol occurred'
+        'partial write of line protocol occurred:\n\t{"line_number":2}'
       )
     })
     it('verifies v3 write error message includes details', () => {
@@ -133,7 +133,16 @@ describe('errors', () => {
         data: ['bad line', true, null],
       })
       expect(new HttpError(400, 'Bad Request', body).message).equals(
-        'partial write of line protocol occurred:\n\tbad line\n\ttrue'
+        'partial write of line protocol occurred:\n\t"bad line"\n\ttrue'
+      )
+    })
+    it('formats line_number without original_line', () => {
+      const body = JSON.stringify({
+        error: 'partial write of line protocol occurred',
+        data: [{error_message: 'bad line', line_number: 3}],
+      })
+      expect(new HttpError(400, 'Bad Request', body).message).equals(
+        'partial write of line protocol occurred:\n\tline 3: bad line'
       )
     })
   })
@@ -199,6 +208,21 @@ describe('errors', () => {
             lineNumber: 2,
             errorMessage: 'bad value',
             originalLine: 'm,t=a value=1',
+          },
+        ],
+      },
+      {
+        title: 'is created from object with error_message and line_number only',
+        body: {
+          error: 'partial write of line protocol occurred',
+          data: {error_message: 'bad value', line_number: 3},
+        },
+        expectPartial: true,
+        expectedLineErrors: [
+          {
+            lineNumber: 3,
+            errorMessage: 'bad value',
+            originalLine: '',
           },
         ],
       },


### PR DESCRIPTION
## Proposed Changes

This PR finalizes partial-write support and fixes regression issue with the default API endpoint behavior introduced in PR #773.

- The client defaults to the V2 API endpoint for writes for broad product compatibility. Since the JS client has not been released yet with the #773 behavior, this change is **not breaking**.
- V3 API-only options:
  - `noSync`
  - `acceptPartial`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
