### PR TITLE
feat: add support for ipv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 2.4.0 [unreleased]
 
+### Bugfix
+
+1. [#864](https://github.com/InfluxCommunity/influxdb3-js/pull/864): Add support for connecting to InfluxDB servers
+   using IPv6 addresses.
+   - IPv6 addresses in server URLs must be enclosed in square brackets, for example, http://[2001:db8::1]:8086.
+   - IPv6 zone identifiers are not currently supported.
+
 ## 2.3.0 [2026-06-11]
 
 ### Features

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -41,7 +41,7 @@ export default class InfluxDBClient {
 
   /**
    * Creates a new instance of the `InfluxDBClient` from connection string.<br>
-   * NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]
+   * NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]:8086, and Zone IDs are not supported.
    * @example https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&database=my-database
    *
    * Supported query parameters:
@@ -64,7 +64,7 @@ export default class InfluxDBClient {
    *
    * Supported variables:
    *   - INFLUX_HOST - cloud/server URL.<br>
-   *   NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1] (required)
+   *   NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]:8086 and Zone IDs are not supported. (required)
    *   - INFLUX_TOKEN - authentication token (required)
    *   - INFLUX_AUTH_SCHEME - token authentication scheme. Not set for Cloud access, set to 'Bearer' for Core/Enterprise.
    *   - INFLUX_TIMEOUT - I/O timeout

--- a/packages/client/src/InfluxDBClient.ts
+++ b/packages/client/src/InfluxDBClient.ts
@@ -40,7 +40,8 @@ export default class InfluxDBClient {
   constructor(options: ClientOptions)
 
   /**
-   * Creates a new instance of the `InfluxDBClient` from connection string.
+   * Creates a new instance of the `InfluxDBClient` from connection string.<br>
+   * NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]
    * @example https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&database=my-database
    *
    * Supported query parameters:
@@ -62,7 +63,8 @@ export default class InfluxDBClient {
    * Creates a new instance of the `InfluxDBClient` from environment variables.
    *
    * Supported variables:
-   *   - INFLUX_HOST - cloud/server URL (required)
+   *   - INFLUX_HOST - cloud/server URL.<br>
+   *   NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1] (required)
    *   - INFLUX_TOKEN - authentication token (required)
    *   - INFLUX_AUTH_SCHEME - token authentication scheme. Not set for Cloud access, set to 'Bearer' for Core/Enterprise.
    *   - INFLUX_TIMEOUT - I/O timeout

--- a/packages/client/src/impl/node/NodeHttpTransport.ts
+++ b/packages/client/src/impl/node/NodeHttpTransport.ts
@@ -15,7 +15,7 @@ import {CLIENT_LIB_USER_AGENT} from '../version'
 import {Log} from '../../util/logger'
 import {pipeline, Readable} from 'stream'
 import {ConnectionOptions} from '../../options'
-import {parseUrl} from '../../util/fixUrl'
+import {urlToHttpOptions} from 'node:url'
 
 const zlibOptions = {
   flush: zlib.constants.Z_SYNC_FLUSH,
@@ -64,19 +64,20 @@ export class NodeHttpTransport implements Transport {
       transportOptions,
       ...nodeSupportedOptions
     } = connectionOptions
-    const url = parseUrl(proxyUrl || _url)
+    const url = new URL(proxyUrl || _url)
+    const {hostname, port, protocol, path} = urlToHttpOptions(url)
     this._token = token
     this._authScheme = authScheme
     this._defaultOptions = {
       ...nodeSupportedOptions,
       ...transportOptions,
-      port: url.port,
-      protocol: url.protocol,
-      hostname: url.hostname,
+      port: port?.toString(),
+      protocol,
+      hostname,
       timeout:
         nodeSupportedOptions.timeout ?? nodeSupportedOptions.writeTimeout,
     }
-    this._contextPath = proxyUrl ? _url : (url.pathname ?? '')
+    this._contextPath = proxyUrl ? _url : (path ?? '')
     if (this._contextPath.endsWith('/')) {
       this._contextPath = this._contextPath.substring(
         0,
@@ -116,7 +117,7 @@ export class NodeHttpTransport implements Transport {
       ...connectionOptions.headers,
     }
     if (proxyUrl) {
-      this._headers['Host'] = parseUrl(_url).host as string
+      this._headers['Host'] = new URL(_url).host as string
     }
   }
 
@@ -289,13 +290,8 @@ export class NodeHttpTransport implements Transport {
       headers.authorization = `${authScheme} ${this._token}`
     }
 
-    // IPv6 square brackets must be stripped before passing to http.request or https.request.
-    const hostname = (this._defaultOptions.hostname as string)
-      .replace('[', '')
-      .replace(']', '')
     const options: {[key: string]: any} = {
       ...this._defaultOptions,
-      hostname: hostname,
       path: this._contextPath + path,
       method: sendOptions.method,
       headers: {

--- a/packages/client/src/impl/node/NodeHttpTransport.ts
+++ b/packages/client/src/impl/node/NodeHttpTransport.ts
@@ -1,9 +1,8 @@
-import {parse} from 'url'
 import * as http from 'http'
 import * as https from 'https'
 import {Buffer} from 'buffer'
-import {RequestTimedOutError, AbortError, HttpError} from '../../errors'
-import {Transport, SendOptions} from '../../transport'
+import {AbortError, HttpError, RequestTimedOutError} from '../../errors'
+import {SendOptions, Transport} from '../../transport'
 import {
   Cancellable,
   CommunicationObserver,
@@ -16,6 +15,7 @@ import {CLIENT_LIB_USER_AGENT} from '../version'
 import {Log} from '../../util/logger'
 import {pipeline, Readable} from 'stream'
 import {ConnectionOptions} from '../../options'
+import {parseUrl} from '../../util/fixUrl'
 
 const zlibOptions = {
   flush: zlib.constants.Z_SYNC_FLUSH,
@@ -64,7 +64,7 @@ export class NodeHttpTransport implements Transport {
       transportOptions,
       ...nodeSupportedOptions
     } = connectionOptions
-    const url = parse(proxyUrl || _url)
+    const url = parseUrl(proxyUrl || _url)
     this._token = token
     this._authScheme = authScheme
     this._defaultOptions = {
@@ -76,7 +76,7 @@ export class NodeHttpTransport implements Transport {
       timeout:
         nodeSupportedOptions.timeout ?? nodeSupportedOptions.writeTimeout,
     }
-    this._contextPath = proxyUrl ? _url : (url.path ?? '')
+    this._contextPath = proxyUrl ? _url : (url.pathname ?? '')
     if (this._contextPath.endsWith('/')) {
       this._contextPath = this._contextPath.substring(
         0,
@@ -116,7 +116,7 @@ export class NodeHttpTransport implements Transport {
       ...connectionOptions.headers,
     }
     if (proxyUrl) {
-      this._headers['Host'] = parse(_url).host as string
+      this._headers['Host'] = parseUrl(_url).host as string
     }
   }
 
@@ -289,8 +289,13 @@ export class NodeHttpTransport implements Transport {
       headers.authorization = `${authScheme} ${this._token}`
     }
 
+    // IPv6 square brackets must be stripped before passing to http.request or https.request.
+    const hostname = (this._defaultOptions.hostname as string)
+      .replace('[', '')
+      .replace(']', '')
     const options: {[key: string]: any} = {
       ...this._defaultOptions,
+      hostname: hostname,
       path: this._contextPath + path,
       method: sendOptions.method,
       headers: {

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -1,11 +1,15 @@
 import {Transport} from './transport'
 import {QParamType} from './QueryApi'
+import {parseUrl} from './util/fixUrl'
 
 /**
  * Option for the communication with InfluxDB server.
  */
 export interface ConnectionOptions {
-  /** base host URL */
+  /**
+   * base host URL.
+   * NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1].
+   */
   host: string
 
   /** authentication token */
@@ -247,18 +251,26 @@ function ensureWriteOptions(options: ClientOptions): WriteOptions {
 }
 
 /**
- * Parses connection string into `ClientOptions`.
+ * Parses connection string into `ClientOptions`<br> NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1].
  * @param connectionString - connection string
  */
 export function fromConnectionString(connectionString: string): ClientOptions {
   if (!connectionString) {
     throw Error('Connection string not set!')
   }
-  const url = new URL(connectionString.trim(), 'http://localhost') // artificial base is ignored when url is absolute
+  connectionString = connectionString.trim()
+  let connectStr = ''
+  if (connectionString.indexOf('://') > 0) {
+    connectStr = connectionString
+  } else {
+    connectStr = `http://localhost${connectionString}`
+  }
+
+  const url = parseUrl(connectStr) // artificial base is ignored when url is absolute
   const options: ClientOptions = {
     host:
       connectionString.indexOf('://') > 0
-        ? url.origin + url.pathname
+        ? `${url.protocol}//${url.hostname}:${url.port}${url.pathname}`
         : url.pathname,
   }
   if (url.searchParams.has('token')) {
@@ -304,6 +316,7 @@ export function fromConnectionString(connectionString: string): ClientOptions {
 
 /**
  * Creates `ClientOptions` from environment variables.
+ * NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]
  */
 export function fromEnv(): ClientOptions {
   if (!process.env.INFLUX_HOST) {

--- a/packages/client/src/options.ts
+++ b/packages/client/src/options.ts
@@ -1,6 +1,5 @@
 import {Transport} from './transport'
 import {QParamType} from './QueryApi'
-import {parseUrl} from './util/fixUrl'
 
 /**
  * Option for the communication with InfluxDB server.
@@ -8,7 +7,7 @@ import {parseUrl} from './util/fixUrl'
 export interface ConnectionOptions {
   /**
    * base host URL.
-   * NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1].
+   * NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]:8086, and Zone IDs are not supported.
    */
   host: string
 
@@ -251,26 +250,18 @@ function ensureWriteOptions(options: ClientOptions): WriteOptions {
 }
 
 /**
- * Parses connection string into `ClientOptions`<br> NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1].
+ * Parses connection string into `ClientOptions`<br> NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]:8086, and Zone IDs are not supported.
  * @param connectionString - connection string
  */
 export function fromConnectionString(connectionString: string): ClientOptions {
   if (!connectionString) {
     throw Error('Connection string not set!')
   }
-  connectionString = connectionString.trim()
-  let connectStr = ''
-  if (connectionString.indexOf('://') > 0) {
-    connectStr = connectionString
-  } else {
-    connectStr = `http://localhost${connectionString}`
-  }
-
-  const url = parseUrl(connectStr) // artificial base is ignored when url is absolute
+  const url = new URL(connectionString.trim(), 'http://localhost') // artificial base is ignored when url is absolute
   const options: ClientOptions = {
     host:
       connectionString.indexOf('://') > 0
-        ? `${url.protocol}//${url.hostname}:${url.port}${url.pathname}`
+        ? url.origin + url.pathname
         : url.pathname,
   }
   if (url.searchParams.has('token')) {
@@ -316,7 +307,7 @@ export function fromConnectionString(connectionString: string): ClientOptions {
 
 /**
  * Creates `ClientOptions` from environment variables.
- * NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]
+ * NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]:8086, and Zone IDs are not supported.
  */
 export function fromEnv(): ClientOptions {
   if (!process.env.INFLUX_HOST) {

--- a/packages/client/src/util/fixUrl.ts
+++ b/packages/client/src/util/fixUrl.ts
@@ -10,103 +10,25 @@ const HTTPS_PREFIX = 'https://'
  * - If the URL starts with "http://", the communication is considered unsafe, and the returned boolean value will be false.
  * - If the URL does not start with either "http://" or "https://", the returned boolean value will be undefined.
  *
- * @param url - The URL to process.
+ * @param input - The URL to process.
  * @returns An object containing the modified URL with the protocol replaced by the port and a boolean value indicating the safety of communication (true for safe, false for unsafe) or undefined if not detected.
  */
 export const replaceURLProtocolWithPort = (
-  url: string
+  input: string
 ): {url: string; safe: boolean | undefined} => {
-  url = url.replace(/\/$/, '')
+  input = input.replace(/\/$/, '')
 
   let safe: boolean | undefined
-
-  if (url.startsWith(HTTP_PREFIX)) {
-    url = url.slice(HTTP_PREFIX.length)
+  if (input.startsWith(HTTP_PREFIX)) {
     safe = false
-
-    if (!url.includes(':')) {
-      url = `${url}:80`
-    }
-  } else if (url.startsWith(HTTPS_PREFIX)) {
-    url = url.slice(HTTPS_PREFIX.length)
+  } else if (input.startsWith(HTTPS_PREFIX)) {
     safe = true
-
-    if (!url.includes(':')) {
-      url = `${url}:443`
-    }
+  } else {
+    return {url: input, safe: undefined}
   }
 
-  return {url, safe}
-}
+  const u = new URL(input)
+  const port = u.port || (u.protocol === 'https:' ? '443' : '80')
 
-/**
- * parseUrl parses the given URL string and returns an object containing its components.
- * It handles both IPv4 and IPv6 addresses, and provides default ports (80 for http, 443 for https) if none are specified.
- *
- * @param url - The URL string to parse.
- * @returns An object containing:
- *  - rawUrl: The original URL string.
- *  - protocol: The protocol (e.g., 'http:', 'https:').
- *  - host: The hostname and port (e.g., 'example.com:80', '[::1]:443').
- *  - hostname: The hostname (e.g., 'example.com', '[::1]').
- *  - port: The port number as a string.
- *  - pathname: The URL path (e.g., '/').
- *  - searchParams: A URLSearchParams object containing the query parameters.
- */
-export const parseUrl = (
-  url: string
-): {
-  rawUrl: string
-  protocol: string
-  host: string
-  hostname: string
-  port: string
-  pathname: string
-  searchParams: URLSearchParams
-} => {
-  let hostname = ''
-  let port = ''
-  if (!url || url.trim() === '') {
-    return {
-      rawUrl: url,
-      protocol: '',
-      host: '',
-      hostname: '',
-      port: '',
-      pathname: '',
-      searchParams: new URLSearchParams(),
-    }
-  }
-
-  // If URL is a IPv6 address
-  const bracketStart = url.indexOf('[')
-  const bracketEnd = url.indexOf(']')
-  let tmpUrl = url
-  const isIpv6 = bracketStart != -1 && bracketEnd !== -1
-  if (isIpv6) {
-    hostname = url.substring(bracketStart, bracketEnd + 1)
-
-    // Temporally set the hostname to [::] so It will not throw "Invalid URL" when passing it into `new URL(url)`
-    tmpUrl = url.replace(hostname, '[::]')
-  }
-
-  const u = new URL(tmpUrl)
-  port = u.port
-  if (port === '') {
-    port = u.protocol.startsWith('https') ? '443' : '80'
-  }
-
-  if (!isIpv6) {
-    hostname = u.hostname
-  }
-
-  return {
-    rawUrl: url,
-    protocol: u.protocol,
-    host: `${hostname}:${port}`,
-    hostname: hostname,
-    port: port,
-    pathname: u.pathname,
-    searchParams: u.searchParams,
-  }
+  return {url: `${u.hostname}:${port}`, safe}
 }

--- a/packages/client/src/util/fixUrl.ts
+++ b/packages/client/src/util/fixUrl.ts
@@ -38,3 +38,75 @@ export const replaceURLProtocolWithPort = (
 
   return {url, safe}
 }
+
+/**
+ * parseUrl parses the given URL string and returns an object containing its components.
+ * It handles both IPv4 and IPv6 addresses, and provides default ports (80 for http, 443 for https) if none are specified.
+ *
+ * @param url - The URL string to parse.
+ * @returns An object containing:
+ *  - rawUrl: The original URL string.
+ *  - protocol: The protocol (e.g., 'http:', 'https:').
+ *  - host: The hostname and port (e.g., 'example.com:80', '[::1]:443').
+ *  - hostname: The hostname (e.g., 'example.com', '[::1]').
+ *  - port: The port number as a string.
+ *  - pathname: The URL path (e.g., '/').
+ *  - searchParams: A URLSearchParams object containing the query parameters.
+ */
+export const parseUrl = (
+  url: string
+): {
+  rawUrl: string
+  protocol: string
+  host: string
+  hostname: string
+  port: string
+  pathname: string
+  searchParams: URLSearchParams
+} => {
+  let hostname = ''
+  let port = ''
+  if (!url || url.trim() === '') {
+    return {
+      rawUrl: url,
+      protocol: '',
+      host: '',
+      hostname: '',
+      port: '',
+      pathname: '',
+      searchParams: new URLSearchParams(),
+    }
+  }
+
+  // If URL is a IPv6 address
+  const bracketStart = url.indexOf('[')
+  const bracketEnd = url.indexOf(']')
+  let tmpUrl = url
+  const isIpv6 = bracketStart != -1 && bracketEnd !== -1
+  if (isIpv6) {
+    hostname = url.substring(bracketStart, bracketEnd + 1)
+
+    // Temporally set the hostname to [::] so It will not throw "Invalid URL" when passing it into `new URL(url)`
+    tmpUrl = url.replace(hostname, '[::]')
+  }
+
+  const u = new URL(tmpUrl)
+  port = u.port
+  if (port === '') {
+    port = u.protocol.startsWith('https') ? '443' : '80'
+  }
+
+  if (!isIpv6) {
+    hostname = u.hostname
+  }
+
+  return {
+    rawUrl: url,
+    protocol: u.protocol,
+    host: `${hostname}:${port}`,
+    hostname: hostname,
+    port: port,
+    pathname: u.pathname,
+    searchParams: u.searchParams,
+  }
+}

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -101,19 +101,13 @@ at 'ClientOptions.database'
         token: 'my-token',
       })
     })
-    it('is created with ipv6', () => {
+    it('is created with ipv6 and ipv4', () => {
       const tests = [
         {
           url: 'http://[2001:db8::1]',
         },
         {
-          url: 'https://[fe80::1%25eth%250]:15000',
-        },
-        {
-          url: 'https://[2001:db8:a0b:12f0::1%25eth0]:15000',
-        },
-        {
-          url: 'https://[fe80::1%25eth%200]',
+          url: 'http://[2001:db8::1]:80',
         },
         {
           url: 'https://example.com:3000',

--- a/packages/client/test/unit/Influxdb.test.ts
+++ b/packages/client/test/unit/Influxdb.test.ts
@@ -101,6 +101,42 @@ at 'ClientOptions.database'
         token: 'my-token',
       })
     })
+    it('is created with ipv6', () => {
+      const tests = [
+        {
+          url: 'http://[2001:db8::1]',
+        },
+        {
+          url: 'https://[fe80::1%25eth%250]:15000',
+        },
+        {
+          url: 'https://[2001:db8:a0b:12f0::1%25eth0]:15000',
+        },
+        {
+          url: 'https://[fe80::1%25eth%200]',
+        },
+        {
+          url: 'https://example.com:3000',
+        },
+        {
+          url: 'http://example.com',
+        },
+      ]
+      for (const test of tests) {
+        expect(
+          (
+            new InfluxDBClient({
+              host: test.url,
+              token: 'my-token',
+            }) as any
+          )._options
+        ).to.deep.equal({
+          ...DEFAULT_ConnectionOptions,
+          host: test.url,
+          token: 'my-token',
+        })
+      }
+    })
     it('is created with host with trailing slash and token', () => {
       expect(
         (

--- a/packages/client/test/unit/Query.test.ts
+++ b/packages/client/test/unit/Query.test.ts
@@ -6,6 +6,7 @@ import {QParamType} from '../../src/QueryApi'
 import {allParamsMatched, queryHasParams} from '../../src/util/sql'
 import {RpcMetadata} from '@protobuf-ts/runtime-rpc'
 import {CLIENT_LIB_VERSION} from '../../src/impl/version'
+import {createQueryTransport} from '../../src/impl/browser/rpc'
 
 const testSQLTicket = {
   db: 'TestDB',
@@ -189,5 +190,14 @@ describe('Query', () => {
     expect(meta['authorization']).to.equal('Bearer TEST_TOKEN')
     expect(meta['hunter']).to.equal('Herbie Hancock')
     expect(meta['feeder']).to.equal('Jefferson Airplane')
+  })
+  it('preserves the browser gRPC context path', () => {
+    const transport: any = createQueryTransport({
+      host: 'https://server.example.com/influx',
+    })
+
+    expect(transport.defaultOptions.baseUrl).to.equal(
+      'https://server.example.com/influx'
+    )
   })
 })

--- a/packages/client/test/unit/impl/browser/FetchTransport.test.ts
+++ b/packages/client/test/unit/impl/browser/FetchTransport.test.ts
@@ -87,6 +87,10 @@ describe('FetchTransport', () => {
         ],
       ])
     })
+    it('preserves a relative host', () => {
+      const transport: any = new FetchTransport({host: '/influx'})
+      expect(transport._url).to.equal('/influx')
+    })
   })
   describe('request', () => {
     const transport = new FetchTransport({host: 'http://test:8086'})

--- a/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -152,6 +152,59 @@ describe('NodeHttpTransport', () => {
       nock.enableNetConnect()
     })
     describe('positive', () => {
+      const tests = [
+        {
+          host: 'http://[2001:db8::1]',
+          hostname: '2001:db8::1',
+        },
+        {
+          host: 'https://[fe80::1%25eth%250]:15000',
+          hostname: 'fe80::1%eth%0',
+        },
+        {
+          host: 'https://[2001:db8:a0b:12f0::1%25eth0]:15000',
+          hostname: '2001:db8:a0b:12f0::1%eth0',
+        },
+        {
+          host: 'https://[fe80::1%25eth%200]',
+          hostname: 'fe80::1%eth 0',
+        },
+        {
+          host: 'https://example.com:3000',
+          hostname: 'example.com',
+        },
+        {
+          host: 'http://example.com',
+          hostname: 'example.com',
+        },
+        {
+          host: 'http://192.168.0.1:8086',
+          hostname: '192.168.0.1',
+        },
+      ]
+
+      for (const test of tests) {
+        it(`passes URL hostname for ${test.host} to the request API`, () => {
+          const request = {
+            on: sinon.stub().returnsThis(),
+            write: sinon.fake(),
+            end: sinon.fake(),
+          }
+          let requestOptions: http.RequestOptions | undefined
+          const requestApi = sinon.fake((options: http.RequestOptions) => {
+            requestOptions = options
+            return request
+          })
+          const transport: any = new NodeHttpTransport({host: test.host})
+          transport._requestApi = requestApi
+
+          transport.send('/test', '', {method: 'GET'})
+
+          expect(requestApi.calledOnce).to.be.true
+          expect(requestOptions?.hostname, test.host).to.equal(test.hostname)
+        })
+      }
+
       const transportOptions = {
         url: TEST_URL,
         timeout: 100,

--- a/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -142,6 +142,14 @@ describe('NodeHttpTransport', () => {
       })
       expect(transport._requestApi).to.equal(http.request)
     })
+    it('preserves the target authority for proxy requests', () => {
+      const transport: any = new NodeHttpTransport({
+        host: 'http://server.example.com',
+        proxyUrl: 'http://proxy.example.com:8080',
+      })
+
+      expect(transport._headers.Host).to.equal('server.example.com')
+    })
   })
   describe('send', () => {
     beforeEach(() => {
@@ -154,20 +162,12 @@ describe('NodeHttpTransport', () => {
     describe('positive', () => {
       const tests = [
         {
-          host: 'http://[2001:db8::1]',
+          host: 'http://[2001:db8::1]:8086',
           hostname: '2001:db8::1',
         },
         {
-          host: 'https://[fe80::1%25eth%250]:15000',
-          hostname: 'fe80::1%eth%0',
-        },
-        {
-          host: 'https://[2001:db8:a0b:12f0::1%25eth0]:15000',
-          hostname: '2001:db8:a0b:12f0::1%eth0',
-        },
-        {
-          host: 'https://[fe80::1%25eth%200]',
-          hostname: 'fe80::1%eth 0',
+          host: 'https://[2001:db8::1]:3000/api?token=mytoken',
+          hostname: '2001:db8::1',
         },
         {
           host: 'https://example.com:3000',

--- a/packages/client/test/unit/options.test.ts
+++ b/packages/client/test/unit/options.test.ts
@@ -31,10 +31,10 @@ describe('ClientOptions', () => {
     it('is created with IPv6', () => {
       expect(
         fromConnectionString(
-          'https://[fe80::1%25eth%250]:15000?token=my-token'
+          'http://[2001:db8::1]:15000?token=my-token'
         ) as ClientOptions
       ).to.deep.equal({
-        host: 'https://[fe80::1%25eth%250]:15000/',
+        host: 'http://[2001:db8::1]:15000/',
         token: 'my-token',
       })
     })
@@ -44,6 +44,14 @@ describe('ClientOptions', () => {
       ).to.deep.equal({
         host: '/influx',
         token: 'my-token',
+      })
+    })
+    it('removes encoded token from the returned host', () => {
+      expect(
+        fromConnectionString('https://server.example.com/influx?token=a%20b')
+      ).to.deep.equal({
+        host: 'https://server.example.com/influx',
+        token: 'a b',
       })
     })
   })

--- a/packages/client/test/unit/options.test.ts
+++ b/packages/client/test/unit/options.test.ts
@@ -28,6 +28,16 @@ describe('ClientOptions', () => {
         token: 'my-token',
       })
     })
+    it('is created with IPv6', () => {
+      expect(
+        fromConnectionString(
+          'https://[fe80::1%25eth%250]:15000?token=my-token'
+        ) as ClientOptions
+      ).to.deep.equal({
+        host: 'https://[fe80::1%25eth%250]:15000/',
+        token: 'my-token',
+      })
+    })
     it('is created with relative URL with token + whitespace around (#213)', () => {
       expect(
         fromConnectionString(' /influx?token=my-token ') as ClientOptions

--- a/packages/client/test/unit/util/utils.test.ts
+++ b/packages/client/test/unit/util/utils.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
-import {throwReturn, collectAll} from '../../../src/util/common'
-import {replaceURLProtocolWithPort} from '../../../src/util/fixUrl'
+import {collectAll, throwReturn} from '../../../src/util/common'
+import {parseUrl, replaceURLProtocolWithPort} from '../../../src/util/fixUrl'
 
 describe('utils', () => {
   it('throwReturn throws given message', () => {
@@ -33,5 +33,123 @@ describe('utils', () => {
     const result = await collectAll(generator)
 
     expect(result).to.deep.equal([4, 5, 6])
+  })
+
+  it('test parseUrl()', () => {
+    const tests = [
+      {
+        url: 'https://192.168.0.5/db',
+        expect: {
+          rawUrl: 'https://192.168.0.5/db',
+          protocol: 'https:',
+          host: '192.168.0.5:443',
+          hostname: '192.168.0.5',
+          port: '443',
+          pathname: '/db',
+          searchParams: new URLSearchParams(),
+        },
+      },
+      {
+        url: 'http://192.168.0.1',
+        expect: {
+          rawUrl: 'http://192.168.0.1',
+          protocol: 'http:',
+          host: '192.168.0.1:80',
+          hostname: '192.168.0.1',
+          port: '80',
+          pathname: '/',
+          searchParams: new URLSearchParams(),
+        },
+      },
+      {
+        url: 'http://[2001:db8::1]?db=bucket0&precision=nanosecond',
+        expect: {
+          rawUrl: 'http://[2001:db8::1]?db=bucket0&precision=nanosecond',
+          protocol: 'http:',
+          host: '[2001:db8::1]:80',
+          hostname: '[2001:db8::1]',
+          port: '80',
+          pathname: '/',
+          searchParams: new URLSearchParams({
+            db: 'bucket0',
+            precision: 'nanosecond',
+          }),
+        },
+      },
+      {
+        url: 'https://[fe80::1%25eth%250]:15000',
+        expect: {
+          rawUrl: 'https://[fe80::1%25eth%250]:15000',
+          protocol: 'https:',
+          host: '[fe80::1%25eth%250]:15000',
+          hostname: '[fe80::1%25eth%250]',
+          port: '15000',
+          pathname: '/',
+          searchParams: new URLSearchParams(),
+        },
+      },
+      {
+        url: 'https://[2001:db8:a0b:12f0::1%25eth0]:15000?db=bucket0&precision=nanosecond',
+        expect: {
+          rawUrl:
+            'https://[2001:db8:a0b:12f0::1%25eth0]:15000?db=bucket0&precision=nanosecond',
+          protocol: 'https:',
+          host: '[2001:db8:a0b:12f0::1%25eth0]:15000',
+          hostname: '[2001:db8:a0b:12f0::1%25eth0]',
+          port: '15000',
+          pathname: '/',
+          searchParams: new URLSearchParams({
+            db: 'bucket0',
+            precision: 'nanosecond',
+          }),
+        },
+      },
+      {
+        url: 'https://[fe80::1%25eth%200]',
+        expect: {
+          rawUrl: 'https://[fe80::1%25eth%200]',
+          protocol: 'https:',
+          host: '[fe80::1%25eth%200]:443',
+          hostname: '[fe80::1%25eth%200]',
+          port: '443',
+          pathname: '/',
+          searchParams: new URLSearchParams(),
+        },
+      },
+      {
+        url: 'https://example.com:3000',
+        expect: {
+          rawUrl: 'https://example.com:3000',
+          protocol: 'https:',
+          host: 'example.com:3000',
+          hostname: 'example.com',
+          port: '3000',
+          pathname: '/',
+          searchParams: new URLSearchParams(),
+        },
+      },
+      {
+        url: 'http://example.com?db=bucket0&precision=nanosecond',
+        expect: {
+          rawUrl: 'http://example.com?db=bucket0&precision=nanosecond',
+          protocol: 'http:',
+          host: 'example.com:80',
+          hostname: 'example.com',
+          port: '80',
+          pathname: '/',
+          searchParams: new URLSearchParams({
+            db: 'bucket0',
+            precision: 'nanosecond',
+          }),
+        },
+      },
+    ]
+    for (const test of tests) {
+      const u = parseUrl(test.url)
+      expect(u.searchParams.toString()).to.be.equals(
+        test.expect.searchParams.toString()
+      )
+      expect(u).to.deep.equal(test.expect)
+    }
   })
 })

--- a/packages/client/test/unit/util/utils.test.ts
+++ b/packages/client/test/unit/util/utils.test.ts
@@ -8,22 +8,52 @@ describe('utils', () => {
     expect(() => throwReturn(new Error(message))).to.throw(message)
   })
 
-  it('fixUrl adds port if not present', () => {
-    expect(replaceURLProtocolWithPort('http://example.com')).to.deep.equal({
-      safe: false,
-      url: 'example.com:80',
+  const fixUrlTests = [
+    {
+      input: 'http://example.com',
+      expected: {safe: false, url: 'example.com:80'},
+    },
+    {
+      input: 'https://example.com',
+      expected: {safe: true, url: 'example.com:443'},
+    },
+    {
+      input: 'http://example.com:3000',
+      expected: {safe: false, url: 'example.com:3000'},
+    },
+    {
+      input: 'https://example.com:5000',
+      expected: {safe: true, url: 'example.com:5000'},
+    },
+    {
+      input: 'http://[2001:db8::1]',
+      expected: {safe: false, url: '[2001:db8::1]:80'},
+    },
+    {
+      input: 'https://[2001:db8::1]',
+      expected: {safe: true, url: '[2001:db8::1]:443'},
+    },
+    {
+      input: 'http://[2001:db8::1]:8086',
+      expected: {safe: false, url: '[2001:db8::1]:8086'},
+    },
+    {
+      input: 'https://[fe80::1%25eth0]',
+      expected: {safe: true, url: '[fe80::1%25eth0]:443'},
+    },
+    {
+      input: 'https://[fe80::1%25eth0]:8086',
+      expected: {safe: true, url: '[fe80::1%25eth0]:8086'},
+    },
+  ]
+
+  for (const test of fixUrlTests) {
+    it(`fixUrl handles ${test.input}`, () => {
+      expect(replaceURLProtocolWithPort(test.input)).to.deep.equal(
+        test.expected
+      )
     })
-    expect(replaceURLProtocolWithPort('https://example.com')).to.deep.equal({
-      safe: true,
-      url: 'example.com:443',
-    })
-    expect(replaceURLProtocolWithPort('http://example.com:3000')).to.deep.equal(
-      {safe: false, url: 'example.com:3000'}
-    )
-    expect(
-      replaceURLProtocolWithPort('https://example.com:5000')
-    ).to.deep.equal({safe: true, url: 'example.com:5000'})
-  })
+  }
 
   it('collectAll correctly iterate through the generator', async () => {
     const generator = (async function* () {

--- a/packages/client/test/unit/util/utils.test.ts
+++ b/packages/client/test/unit/util/utils.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
-import {collectAll, throwReturn} from '../../../src/util/common'
-import {parseUrl, replaceURLProtocolWithPort} from '../../../src/util/fixUrl'
+import {throwReturn, collectAll} from '../../../src/util/common'
+import {replaceURLProtocolWithPort} from '../../../src/util/fixUrl'
 
 describe('utils', () => {
   it('throwReturn throws given message', () => {
@@ -8,52 +8,55 @@ describe('utils', () => {
     expect(() => throwReturn(new Error(message))).to.throw(message)
   })
 
-  const fixUrlTests = [
-    {
-      input: 'http://example.com',
-      expected: {safe: false, url: 'example.com:80'},
-    },
-    {
-      input: 'https://example.com',
-      expected: {safe: true, url: 'example.com:443'},
-    },
-    {
-      input: 'http://example.com:3000',
-      expected: {safe: false, url: 'example.com:3000'},
-    },
-    {
-      input: 'https://example.com:5000',
-      expected: {safe: true, url: 'example.com:5000'},
-    },
-    {
-      input: 'http://[2001:db8::1]',
-      expected: {safe: false, url: '[2001:db8::1]:80'},
-    },
-    {
-      input: 'https://[2001:db8::1]',
-      expected: {safe: true, url: '[2001:db8::1]:443'},
-    },
-    {
-      input: 'http://[2001:db8::1]:8086',
-      expected: {safe: false, url: '[2001:db8::1]:8086'},
-    },
-    {
-      input: 'https://[fe80::1%25eth0]',
-      expected: {safe: true, url: '[fe80::1%eth0]:443'},
-    },
-    {
-      input: 'https://[fe80::1%25eth0]:8086',
-      expected: {safe: true, url: '[fe80::1%eth0]:8086'},
-    },
-  ]
-
-  for (const test of fixUrlTests) {
-    it(`fixUrl handles ${test.input}`, () => {
-      expect(replaceURLProtocolWithPort(test.input)).to.deep.equal(
-        test.expected
-      )
+  it('fixUrl adds port if not present', () => {
+    expect(replaceURLProtocolWithPort('http://example.com')).to.deep.equal({
+      safe: false,
+      url: 'example.com:80',
     })
-  }
+    expect(replaceURLProtocolWithPort('https://example.com')).to.deep.equal({
+      safe: true,
+      url: 'example.com:443',
+    })
+    expect(replaceURLProtocolWithPort('http://example.com:3000')).to.deep.equal(
+      {safe: false, url: 'example.com:3000'}
+    )
+    expect(
+      replaceURLProtocolWithPort('https://example.com:5000')
+    ).to.deep.equal({safe: true, url: 'example.com:5000'})
+
+    expect(replaceURLProtocolWithPort('http://[2001:db8::1]')).to.deep.equal({
+      safe: false,
+      url: '[2001:db8::1]:80',
+    })
+    expect(replaceURLProtocolWithPort('https://[2001:db8::1]')).to.deep.equal({
+      safe: true,
+      url: '[2001:db8::1]:443',
+    })
+    expect(
+      replaceURLProtocolWithPort('http://[2001:db8::1]:8086')
+    ).to.deep.equal({
+      safe: false,
+      url: '[2001:db8::1]:8086',
+    })
+    expect(
+      replaceURLProtocolWithPort('https://[2001:db8::1]:8086')
+    ).to.deep.equal({
+      safe: true,
+      url: '[2001:db8::1]:8086',
+    })
+    expect(
+      replaceURLProtocolWithPort('https://[2001:db8::1]:443')
+    ).to.deep.equal({
+      safe: true,
+      url: '[2001:db8::1]:443',
+    })
+    expect(
+      replaceURLProtocolWithPort('https://[2001:db8::1]:8086/influx')
+    ).to.deep.equal({
+      safe: true,
+      url: '[2001:db8::1]:8086',
+    })
+  })
 
   it('collectAll correctly iterate through the generator', async () => {
     const generator = (async function* () {
@@ -63,123 +66,5 @@ describe('utils', () => {
     const result = await collectAll(generator)
 
     expect(result).to.deep.equal([4, 5, 6])
-  })
-
-  it('test parseUrl()', () => {
-    const tests = [
-      {
-        url: 'https://192.168.0.5/db',
-        expect: {
-          rawUrl: 'https://192.168.0.5/db',
-          protocol: 'https:',
-          host: '192.168.0.5:443',
-          hostname: '192.168.0.5',
-          port: '443',
-          pathname: '/db',
-          searchParams: new URLSearchParams(),
-        },
-      },
-      {
-        url: 'http://192.168.0.1',
-        expect: {
-          rawUrl: 'http://192.168.0.1',
-          protocol: 'http:',
-          host: '192.168.0.1:80',
-          hostname: '192.168.0.1',
-          port: '80',
-          pathname: '/',
-          searchParams: new URLSearchParams(),
-        },
-      },
-      {
-        url: 'http://[2001:db8::1]?db=bucket0&precision=nanosecond',
-        expect: {
-          rawUrl: 'http://[2001:db8::1]?db=bucket0&precision=nanosecond',
-          protocol: 'http:',
-          host: '[2001:db8::1]:80',
-          hostname: '[2001:db8::1]',
-          port: '80',
-          pathname: '/',
-          searchParams: new URLSearchParams({
-            db: 'bucket0',
-            precision: 'nanosecond',
-          }),
-        },
-      },
-      {
-        url: 'https://[fe80::1%25eth%250]:15000',
-        expect: {
-          rawUrl: 'https://[fe80::1%25eth%250]:15000',
-          protocol: 'https:',
-          host: '[fe80::1%25eth%250]:15000',
-          hostname: '[fe80::1%25eth%250]',
-          port: '15000',
-          pathname: '/',
-          searchParams: new URLSearchParams(),
-        },
-      },
-      {
-        url: 'https://[2001:db8:a0b:12f0::1%25eth0]:15000?db=bucket0&precision=nanosecond',
-        expect: {
-          rawUrl:
-            'https://[2001:db8:a0b:12f0::1%25eth0]:15000?db=bucket0&precision=nanosecond',
-          protocol: 'https:',
-          host: '[2001:db8:a0b:12f0::1%25eth0]:15000',
-          hostname: '[2001:db8:a0b:12f0::1%25eth0]',
-          port: '15000',
-          pathname: '/',
-          searchParams: new URLSearchParams({
-            db: 'bucket0',
-            precision: 'nanosecond',
-          }),
-        },
-      },
-      {
-        url: 'https://[fe80::1%25eth%200]',
-        expect: {
-          rawUrl: 'https://[fe80::1%25eth%200]',
-          protocol: 'https:',
-          host: '[fe80::1%25eth%200]:443',
-          hostname: '[fe80::1%25eth%200]',
-          port: '443',
-          pathname: '/',
-          searchParams: new URLSearchParams(),
-        },
-      },
-      {
-        url: 'https://example.com:3000',
-        expect: {
-          rawUrl: 'https://example.com:3000',
-          protocol: 'https:',
-          host: 'example.com:3000',
-          hostname: 'example.com',
-          port: '3000',
-          pathname: '/',
-          searchParams: new URLSearchParams(),
-        },
-      },
-      {
-        url: 'http://example.com?db=bucket0&precision=nanosecond',
-        expect: {
-          rawUrl: 'http://example.com?db=bucket0&precision=nanosecond',
-          protocol: 'http:',
-          host: 'example.com:80',
-          hostname: 'example.com',
-          port: '80',
-          pathname: '/',
-          searchParams: new URLSearchParams({
-            db: 'bucket0',
-            precision: 'nanosecond',
-          }),
-        },
-      },
-    ]
-    for (const test of tests) {
-      const u = parseUrl(test.url)
-      expect(u.searchParams.toString()).to.be.equals(
-        test.expect.searchParams.toString()
-      )
-      expect(u).to.deep.equal(test.expect)
-    }
   })
 })

--- a/packages/client/test/unit/util/utils.test.ts
+++ b/packages/client/test/unit/util/utils.test.ts
@@ -39,11 +39,11 @@ describe('utils', () => {
     },
     {
       input: 'https://[fe80::1%25eth0]',
-      expected: {safe: true, url: '[fe80::1%25eth0]:443'},
+      expected: {safe: true, url: '[fe80::1%eth0]:443'},
     },
     {
       input: 'https://[fe80::1%25eth0]:8086',
-      expected: {safe: true, url: '[fe80::1%25eth0]:8086'},
+      expected: {safe: true, url: '[fe80::1%eth0]:8086'},
     },
   ]
 


### PR DESCRIPTION
Closes #

## Proposed Changes

- Add tests for IPv6, I only check if our clients can parse the addresses correctly. Real communication tests need to be created inside a machine executor in CircleCI, and It is not worth the efforts, already talked with Jakub about this.
- After some researching on how our communication packages work with IPv6 and Zone id we concluded that trying to support IPv6 with Zone id is not worth the efforts; we only add support for IPv6 because:
  - `fetch` does not work with zone ids.
  - `grpcweb-transport` uses `fetch` under the hood, so it will also fail when using zone ids.
  - `http.request` and `https.request` not 100% sure it can work reliably with zone ids.
  -  `grpc-transport` not 100% sure it can work reliably with zone ids.
- Documents added to warn users that we don't support IPv6 with Zone IDs yet.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
