### PR TITLE
fix: replace legacy url.parse() with WHATWG URL in NodeHttpTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.4.0 [unreleased]
 
+### Bugfix
+
+1. [#874](https://github.com/InfluxCommunity/influxdb3-js/pull/874): `NodeHttpTransport` now uses the WHATWG `URL` API instead of the legacy, deprecated `url.parse()`, avoiding a `DEP0169` `DeprecationWarning` logged on every client construction under Node.
+
 ## 2.3.0 [2026-06-11]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bugfix
 
-1. [#874](https://github.com/InfluxCommunity/influxdb3-js/pull/874): `NodeHttpTransport` now uses the WHATWG `URL` API instead of the legacy, deprecated `url.parse()`, avoiding a `DEP0169` `DeprecationWarning` logged on every client construction under Node.
+1. [#874](https://github.com/InfluxCommunity/influxdb3-js/pull/874): `NodeHttpTransport` now uses the WHATWG `URL` API instead of the legacy, deprecated `url.parse()`, avoiding a `DEP0169` `DeprecationWarning` logged on every client construction under Node. IPv6 hosts (e.g. `http://[::1]:8086`) keep connecting correctly; the brackets `URL` adds around the literal are stripped before being passed to `http(s).request()`.
 
 ## 2.3.0 [2026-06-11]
 

--- a/packages/client/src/impl/node/NodeHttpTransport.ts
+++ b/packages/client/src/impl/node/NodeHttpTransport.ts
@@ -1,4 +1,3 @@
-import {parse} from 'url'
 import * as http from 'http'
 import * as https from 'https'
 import {Buffer} from 'buffer'
@@ -64,19 +63,22 @@ export class NodeHttpTransport implements Transport {
       transportOptions,
       ...nodeSupportedOptions
     } = connectionOptions
-    const url = parse(proxyUrl || _url)
+    const url = new URL(proxyUrl || _url)
     this._token = token
     this._authScheme = authScheme
     this._defaultOptions = {
       ...nodeSupportedOptions,
       ...transportOptions,
-      port: url.port,
+      // url.port is '' (not null, unlike the legacy url.parse()) when the URL has no
+      // explicit port; normalize to undefined so the cleanup below strips it and
+      // http(s).request() falls back to the protocol's default port.
+      port: url.port || undefined,
       protocol: url.protocol,
       hostname: url.hostname,
       timeout:
         nodeSupportedOptions.timeout ?? nodeSupportedOptions.writeTimeout,
     }
-    this._contextPath = proxyUrl ? _url : (url.path ?? '')
+    this._contextPath = proxyUrl ? _url : url.pathname + url.search
     if (this._contextPath.endsWith('/')) {
       this._contextPath = this._contextPath.substring(
         0,
@@ -116,7 +118,7 @@ export class NodeHttpTransport implements Transport {
       ...connectionOptions.headers,
     }
     if (proxyUrl) {
-      this._headers['Host'] = parse(_url).host as string
+      this._headers['Host'] = new URL(_url).host
     }
   }
 

--- a/packages/client/src/impl/node/NodeHttpTransport.ts
+++ b/packages/client/src/impl/node/NodeHttpTransport.ts
@@ -22,6 +22,14 @@ const zlibOptions = {
 }
 const emptyBuffer = Buffer.allocUnsafe(0)
 
+// WHATWG URL wraps IPv6 literals in brackets (e.g. "[::1]"), but Node's
+// http(s).request() `hostname` option must be the bare address.
+function stripIPv6Brackets(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname
+}
+
 class CancellableImpl implements Cancellable {
   private _cancelled = false
   public resume?: () => void
@@ -74,7 +82,10 @@ export class NodeHttpTransport implements Transport {
       // http(s).request() falls back to the protocol's default port.
       port: url.port || undefined,
       protocol: url.protocol,
-      hostname: url.hostname,
+      // url.hostname keeps the brackets around an IPv6 literal (e.g. "[::1]"), but
+      // http(s).request()'s `hostname` option needs the bare address or it fails DNS
+      // lookup on the literal brackets.
+      hostname: stripIPv6Brackets(url.hostname),
       timeout:
         nodeSupportedOptions.timeout ?? nodeSupportedOptions.writeTimeout,
     }

--- a/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
+++ b/packages/client/test/unit/impl/node/NodeHttpTransport.test.ts
@@ -87,6 +87,17 @@ describe('NodeHttpTransport', () => {
       })
       expect(transport._requestApi).to.equal(https.request)
     })
+    it('strips brackets from an IPv6 host', () => {
+      const transport: any = new NodeHttpTransport({
+        host: 'http://[::1]:8086',
+      })
+      expect(transport._defaultOptions).to.deep.equal({
+        hostname: '::1',
+        port: '8086',
+        protocol: 'http:',
+      })
+      expect(transport._requestApi).to.equal(http.request)
+    })
     it('creates the transport with _contextPath', () => {
       const transport: any = new NodeHttpTransport({
         host: 'http://test:8086/influx',
@@ -489,6 +500,33 @@ describe('NodeHttpTransport', () => {
             throw e
           })
       })
+    })
+  })
+  describe('send over IPv6', () => {
+    let server: http.Server
+    let url = ''
+    before(async () => {
+      await new Promise<void>((resolve, reject) => {
+        server = http.createServer((_req, res) => res.end('ipv6 ok'))
+        server.listen(0, '::1', () => {
+          const addr = server.address() as AddressInfo
+          url = `http://[::1]:${addr.port}`
+          resolve()
+        })
+        server.on('error', reject)
+      })
+    })
+    after(() => {
+      server.close()
+    })
+    it('connects to a bracketed IPv6 host', async () => {
+      const data = await sendTestData(
+        {host: url, timeout: 10000},
+        {
+          method: 'GET',
+        }
+      )
+      expect(data).to.equal('ipv6 ok')
     })
   })
   describe('send.backpressure', () => {


### PR DESCRIPTION
## Problem

`NodeHttpTransport` parses the `host`/`proxyUrl` connection option with the legacy
`url.parse()` API. Since Node's `url.parse()` was deprecated (`DEP0169`), this logs a
`DeprecationWarning` on every `InfluxDBClient` construction under recent Node versions
(reproduced on Node 24):

```
(node:1) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and
prone to errors that have security implications. Use the WHATWG URL API instead.
CVEs are not issued for `url.parse()` vulnerabilities.
    at urlParse (node:url:136:13)
    at new NodeHttpTransport (.../impl/node/NodeHttpTransport.ts:67:8)
    ...
```

In a Lambda/serverless context this shows up as a noisy `ERROR`-level log line on every
cold start, with no way to fix it from the consuming application since the call is
internal to the SDK.

## Proposed Changes

**Commit 1 — replace `url.parse()` with WHATWG `URL`:**

- Replace `import {parse} from 'url'` with the global WHATWG `URL` class in
  `NodeHttpTransport` (both the `host`/`proxyUrl` parse in the constructor and the
  `Host` header parse used for proxying).
- `URL` is a global since Node 10, so no new import is needed and the package's
  `"node": ">=20"` engines requirement is unaffected.
- One behavioral note: `URL.port` returns `''` for a URL with no explicit port,
  whereas `url.parse().port` returned `null`. Normalized this to `undefined` before
  it lands in `_defaultOptions`, so the existing "strip undefined keys" cleanup still
  removes it and `http(s).request()` falls back to the protocol's default port exactly
  as before.

**Commit 2 — preserve IPv6 connectivity (per review feedback):**

- `URL.hostname` keeps the brackets around an IPv6 literal (e.g. `[::1]`), but
  `http(s).request()`'s `hostname` option needs the bare address — passing it the
  bracketed form fails DNS lookup (`ENOTFOUND [::1]`). Added a small
  `stripIPv6Brackets()` helper and applied it before the hostname lands in
  `_defaultOptions`.
- Added a regression test that actually connects `NodeHttpTransport` to a server
  bound to the `::1` loopback (fails with `ENOTFOUND [::1]` without the fix), plus a
  constructor-level unit test asserting `_defaultOptions.hostname` is the bare
  address for a bracketed IPv6 host.

Both commits include a matching `CHANGELOG.md` entry under `2.4.0 [unreleased]`.

## Verification

- `yarn test:unit` — 347 unit tests pass, including all `NodeHttpTransport` tests
  (constructor option shape, http/https selection, context path handling, proxy
  `Host` header, IPv6 host handling, send/iterate/request behavior).
- `yarn lint` — clean (0 errors).
- Manually confirmed the `DEP0169` warning is gone: constructed a `NodeHttpTransport`
  with a `process.on('warning', ...)` listener before and after the change — before:
  fires with `code === 'DEP0169'`; after: never fires.
- Manually confirmed the IPv6 regression before fixing it: reverting just the
  hostname-stripping change reproduces `ENOTFOUND [::1]` on the new IPv6 test, and
  the constructor test's expected `_defaultOptions.hostname` mismatches
  (`'[::1]'` vs `'::1'`).
- No functional change intended/observed to host/port/protocol/context-path
  resolution for any of the existing test cases (http, https, with/without path,
  trailing slash, `/api/v2` suffix warning, unsupported scheme, proxy `Host` header).

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
